### PR TITLE
Wii Classic Controller support WIP (doesn’t work, but please read)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,13 +62,13 @@ if ( NOT INFONES_PLUS_USE_ALTERNATE_HW_CONFIG )
 	set(DVICONFIG "dviConfig_PimoroniDemoDVSock" CACHE STRING
 	  "Select a default pin configuration from common_dvi_pin_configs.h")
 	set(SD_CS "22" CACHE STRING "Specify the Chip Select GPIO pin for the SD card")
-	set(SD_SCK "5" CACHE STRING "Specify de Clock GPIO pin for the SD card")
+	set(SD_SCK "5" CACHE STRING "Specify the Clock GPIO pin for the SD card")
 	set(SD_MOSI "18" CACHE STRING "Select the Master Out Slave In GPIO pin for the SD card")
 	set(SD_MISO "19" CACHE STRING "Select the Master In Slave Out GPIO pin for the SD card")
 	set(NES_CLK "14" CACHE STRING "Select the Clock GPIO pin for NES controller")
 	set(NES_DATA "15" CACHE STRING "Select the Data GPIO pin for NES controller")
 	set(NES_LAT "16" CACHE STRING "Select the Latch GPIO pin for NES controller")
-else()
+elseif ( INFONES_PLUS_USE_ALTERNATE_HW_CONFIG EQUAL 1 )
 	# --------------------------------------------------------------------
 	# Alternate config for use with different SDcard reader and HDMI board
 	# --------------------------------------------------------------------
@@ -78,12 +78,28 @@ else()
 
 	# Adafruit Micro-SD breakout board+ https://www.adafruit.com/product/254 
 	set(SD_CS "5" CACHE STRING "Specify the Chip Select GPIO pin for the SD card")
-	set(SD_SCK "2" CACHE STRING "Specify de Clock GPIO pin for the SD card")
+	set(SD_SCK "2" CACHE STRING "Specify the Clock GPIO pin for the SD card")
 	set(SD_MOSI "3" CACHE STRING "Select the Master Out Slave In GPIO pin for the SD card")
 	set(SD_MISO "4" CACHE STRING "Select the Master In Slave Out GPIO pin for the SD card")
 	set(NES_CLK "6" CACHE STRING "Select the Clock GPIO pin for NES controller")
 	set(NES_DATA "7" CACHE STRING "Select the Data GPIO pin for NES controller")
 	set(NES_LAT "8" CACHE STRING "Select the Latch GPIO pin for NES controller")
+elseif ( INFONES_PLUS_USE_ALTERNATE_HW_CONFIG EQUAL 2 )
+	# --------------------------------------------------------------------
+	# Alternate config for use with Adafruit Feather RP2040 DVI
+	# --------------------------------------------------------------------
+	set(DVICONFIG "dviConfig_AdafruitFeatherDVI" CACHE STRING
+	"Select a default pin configuration from common_dvi_pin_configs.h")
+
+	# Adafruit Adalogger FeatherWing
+	set(SD_CS "10" CACHE STRING "Specify the Chip Select GPIO pin for the SD card")
+	set(SD_SCK "14" CACHE STRING "Specify the Clock GPIO pin for the SD card")
+	set(SD_MOSI "15" CACHE STRING "Select the Master Out Slave In GPIO pin for the SD card")
+	set(SD_MISO "8" CACHE STRING "Select the Master In Slave Out GPIO pin for the SD card")
+	set(NES_CLK "9" CACHE STRING "Select the Clock GPIO pin for NES controller")
+	set(NES_DATA "10" CACHE STRING "Select the Data GPIO pin for NES controller")
+	set(NES_LAT "11" CACHE STRING "Select the Latch GPIO pin for NES controller")
+
 endif ( NOT INFONES_PLUS_USE_ALTERNATE_HW_CONFIG )
 # --------------------------------------------------------------------
 message("HDMI board type     : ${DVICONFIG}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,9 +96,9 @@ elseif ( INFONES_PLUS_USE_ALTERNATE_HW_CONFIG EQUAL 2 )
 	set(SD_SCK "14" CACHE STRING "Specify the Clock GPIO pin for the SD card")
 	set(SD_MOSI "15" CACHE STRING "Select the Master Out Slave In GPIO pin for the SD card")
 	set(SD_MISO "8" CACHE STRING "Select the Master In Slave Out GPIO pin for the SD card")
-	set(NES_CLK "9" CACHE STRING "Select the Clock GPIO pin for NES controller")
-	set(NES_DATA "10" CACHE STRING "Select the Data GPIO pin for NES controller")
-	set(NES_LAT "11" CACHE STRING "Select the Latch GPIO pin for NES controller")
+	set(NES_CLK "5" CACHE STRING "Select the Clock GPIO pin for NES controller")
+	set(NES_DATA "6" CACHE STRING "Select the Data GPIO pin for NES controller")
+	set(NES_LAT "9" CACHE STRING "Select the Latch GPIO pin for NES controller")
 
 endif ( NOT INFONES_PLUS_USE_ALTERNATE_HW_CONFIG )
 # --------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,9 @@ if ( NOT INFONES_PLUS_USE_ALTERNATE_HW_CONFIG )
 	set(NES_CLK "14" CACHE STRING "Select the Clock GPIO pin for NES controller")
 	set(NES_DATA "15" CACHE STRING "Select the Data GPIO pin for NES controller")
 	set(NES_LAT "16" CACHE STRING "Select the Latch GPIO pin for NES controller")
+	set(WII_SDA "-1" CACHE STRING "Select the SDA GPIO pin for Wii Classic controller")
+	set(WII_SCL "-1" CACHE STRING "Select the SCL GPIO pin for Wii Classic controller")
+	set(LED_GPIO_PIN "-1" CACHE STRING "Select the GPIO pin for LED")
 elseif ( INFONES_PLUS_USE_ALTERNATE_HW_CONFIG EQUAL 1 )
 	# --------------------------------------------------------------------
 	# Alternate config for use with different SDcard reader and HDMI board
@@ -84,6 +87,9 @@ elseif ( INFONES_PLUS_USE_ALTERNATE_HW_CONFIG EQUAL 1 )
 	set(NES_CLK "6" CACHE STRING "Select the Clock GPIO pin for NES controller")
 	set(NES_DATA "7" CACHE STRING "Select the Data GPIO pin for NES controller")
 	set(NES_LAT "8" CACHE STRING "Select the Latch GPIO pin for NES controller")
+	set(WII_SDA "-1" CACHE STRING "Select the SDA GPIO pin for Wii Classic controller")
+	set(WII_SCL "-1" CACHE STRING "Select the SCL GPIO pin for Wii Classic controller")
+	set(LED_GPIO_PIN "13" CACHE STRING "Select the GPIO pin for LED")
 elseif ( INFONES_PLUS_USE_ALTERNATE_HW_CONFIG EQUAL 2 )
 	# --------------------------------------------------------------------
 	# Alternate config for use with Adafruit Feather RP2040 DVI
@@ -99,6 +105,9 @@ elseif ( INFONES_PLUS_USE_ALTERNATE_HW_CONFIG EQUAL 2 )
 	set(NES_CLK "5" CACHE STRING "Select the Clock GPIO pin for NES controller")
 	set(NES_DATA "6" CACHE STRING "Select the Data GPIO pin for NES controller")
 	set(NES_LAT "9" CACHE STRING "Select the Latch GPIO pin for NES controller")
+	set(WII_SDA "2" CACHE STRING "Select the SDA GPIO pin for Wii Classic controller")
+	set(WII_SCL "3" CACHE STRING "Select the SCL GPIO pin for Wii Classic controller")
+	set(LED_GPIO_PIN "13" CACHE STRING "Select the GPIO pin for LED")
 
 endif ( NOT INFONES_PLUS_USE_ALTERNATE_HW_CONFIG )
 # --------------------------------------------------------------------
@@ -110,6 +119,9 @@ message("SD card MISO        : ${SD_MISO}")
 message("NES controller CLK  : ${NES_CLK}")
 message("NES controller DATA : ${NES_DATA}")
 message("NES controller LAT  : ${NES_LAT}")
+message("Wii controller SDA  : ${WII_SDA}")
+message("Wii controller SCL  : ${WII_SCL}")
+message("LED pin             : ${LED_GPIO_PIN}")
 
 if (  INFONES_PLUS_DISABLE_LED ) 
     set(LED_DISABLED 1 CACHE STRING "Select whether to disable or enable the on board LED")
@@ -122,6 +134,7 @@ add_executable(piconesPlus
     hid_app.cpp
     gamepad.cpp
     nespad.cpp
+    wiipad.cpp
     menu.cpp
     RomLister.cpp
     FrensHelpers.cpp
@@ -151,7 +164,10 @@ target_compile_definitions(piconesPlus PRIVATE
     NES_PIN_CLK=${NES_CLK}
     NES_PIN_DATA=${NES_DATA}
     NES_PIN_LAT=${NES_LAT}
+    WII_PIN_SDA=${WII_SDA}
+    WII_PIN_SCL=${WII_SCL}
     LED_DISABLED=${LED_DISABLED}
+    LED_GPIO_PIN=${LED_GPIO_PIN}
 )
 target_link_libraries(piconesPlus PRIVATE
     pico_stdlib

--- a/buildAll.sh
+++ b/buildAll.sh
@@ -19,6 +19,11 @@ cd `dirname $0` || exit 1
 if [ -f build/piconesPlus.uf2 ] ; then
 	cp build/piconesPlus.uf2 releases/piconesPlusAdaFruitDVISD.uf2 || exit 1
 fi
+cd `dirname $0` || exit 1
+./build_alternate_2.sh
+if [ -f build/piconesPlus.uf2 ] ; then
+	cp build/piconesPlus.uf2 releases/piconesPlusAdafruitFeather.uf2 || exit 1
+fi
 ls -l releases
 unset RETAINSDK
 . ./removetmpsdk.sh

--- a/build_alternate_2.sh
+++ b/build_alternate_2.sh
@@ -1,0 +1,22 @@
+:
+# ====================================================================================
+# PICO-INFONESPLUS build script with alternate configuration 2
+# Builds the emulator for use with the
+# AdaFruit Feather RP2040 DVI
+#         https://www.adafruit.com/product/TBD
+# and the 
+# AdaFruit Adalogger FeatherWing
+#         https://www.adafruit.com/product/2922
+# (or connect SD breakout using same pins as FeatherWing)
+# ====================================================================================
+cd `dirname $0` || exit 1
+. ./checksdk.sh
+if [ -d build ] ; then
+	rm -rf build || exit 1
+	mkdir build || exit 1
+fi
+cd build || exit 1
+cmake -DCMAKE_BUILD_TYPE=RELEASENODEBUG -DINFONES_PLUS_USE_ALTERNATE_HW_CONFIG=2 ..
+make -j 4
+cd ..
+. ./removetmpsdk.sh

--- a/build_alternate_2_debug.sh
+++ b/build_alternate_2_debug.sh
@@ -1,0 +1,22 @@
+:
+# ====================================================================================
+# PICO-INFONESPLUS build script with alternate configuration 2 and debug enabled
+# Builds the emulator for use with the
+# AdaFruit Feather RP2040 DVI
+#         https://www.adafruit.com/product/TBD
+# and the 
+# AdaFruit Adalogger FeatherWing
+#         https://www.adafruit.com/product/2922
+# (or connect SD breakout using same pins as FeatherWing)
+# ====================================================================================
+cd `dirname $0` || exit 1
+. ./checksdk.sh
+if [ -d build ] ; then
+	rm -rf build || exit 1
+	mkdir build || exit 1
+fi
+cd build || exit 1
+cmake -DCMAKE_BUILD_TYPE=DEBUG -DINFONES_PLUS_USE_ALTERNATE_HW_CONFIG=2 ..
+make -j 4
+cd ..
+. ./removetmpsdk.sh

--- a/include/common_dvi_pin_configs.h
+++ b/include/common_dvi_pin_configs.h
@@ -88,4 +88,13 @@ static const struct dvi_serialiser_cfg not_hdmi_featherwing_cfg = {
 	.invert_diffpairs = true
 };
 
+// Adafruit Feather RP2040 DVI
+static const struct dvi_serialiser_cfg adafruit_feather_dvi_cfg = {
+	.pio = DVI_DEFAULT_PIO_INST,
+	.sm_tmds = {0, 1, 2},
+	.pins_tmds = {18, 20, 22},
+	.pins_clk = 16,
+	.invert_diffpairs = true
+};
+
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -75,6 +75,12 @@ namespace
         .pinClock = 6,
         .invert = true,
     };
+    // Adafruit Feather RP2040 DVI
+    constexpr dvi::Config dviConfig_AdafruitFeatherDVI = {
+        .pinTMDS = {18, 20, 22},
+        .pinClock = 16,
+        .invert = true,
+    };
 
     std::unique_ptr<dvi::DVI> dvi_;
 

--- a/main.cpp
+++ b/main.cpp
@@ -32,6 +32,7 @@
 #include "rom_selector.h"
 #include "menu.h"
 #include "nespad.h"
+#include "wiipad.h"
 
 #ifdef __cplusplus
 
@@ -39,9 +40,12 @@
 
 #endif
 
-
 #if LED_DISABLED == 0
+#if LED_GPIO_PIN >= 0
+const uint LED_PIN = LED_GPIO_PIN;
+#else
 const uint LED_PIN = PICO_DEFAULT_LED_PIN;
+#endif
 #endif 
 #ifndef DVICONFIG
 #define DVICONFIG dviConfig_PimoroniDemoDVSock
@@ -327,7 +331,13 @@ void InfoNES_PadState(DWORD *pdwPad1, DWORD *pdwPad2, DWORD *pdwSystem)
                 (gp.buttons & io::GamePadState::Button::SELECT ? SELECT : 0) |
                 (gp.buttons & io::GamePadState::Button::START ? START : 0) |
                 0;
-        if (i == 0) v |= nespad_state;
+        //if (i == 0) v |= nespad_state;
+        if (i == 0) {
+            v |= nespad_state;
+#if WII_PIN_SDA >= 0 and WII_PIN_SCL >= 0
+            v |= wiipad_read();
+#endif
+        }
 
         int rv = v;
         if (rapidFireCounter & 2)
@@ -803,6 +813,9 @@ int main()
     applyScreenMode();
 
     nespad_begin(CPUFreqKHz, NES_PIN_CLK, NES_PIN_DATA, NES_PIN_LAT);
+#if WII_PIN_SDA >= 0 and WII_PIN_SCL >= 0
+    wiipad_begin();
+#endif
 
     // 空サンプル詰めとく
     dvi_->getAudioRingBuffer().advanceWritePointer(255);

--- a/menu.cpp
+++ b/menu.cpp
@@ -13,6 +13,7 @@
 #include "RomLister.h"
 #include "menu.h"
 #include "nespad.h"
+#include "wiipad.h"
 
 #include "font_8x8.h"
 #define FONT_CHAR_WIDTH 8
@@ -89,6 +90,9 @@ void RomSelect_PadState(DWORD *pdwPad1, bool ignorepushed = false)
             (gp.buttons & io::GamePadState::Button::Y ? Y : 0) |
             0;
     v |= nespad_state;
+#if WII_PIN_SDA >= 0 and WII_PIN_SCL >= 0
+    v |= wiipad_read();
+#endif
 
     *pdwPad1 = 0;
    

--- a/wiipad.cpp
+++ b/wiipad.cpp
@@ -1,8 +1,8 @@
+#if WII_PIN_SDA >= 0 and WII_PIN_SCL >= 0
+
 #include "pico/stdlib.h"
 #include "hardware/i2c.h"
 #include "wiipad.h"
-
-#if WII_PIN_SDA >= 0 and WII_PIN_SCL >= 0
 
 void wiipad_begin(void) {
     i2c_init(WII_I2C, 400000);
@@ -46,4 +46,4 @@ uint8_t wiipad_read(void) {
     return v;
 }
 
-#endif
+#endif // end WII_PIN_SDA + WII_PIN_SCL

--- a/wiipad.cpp
+++ b/wiipad.cpp
@@ -1,0 +1,50 @@
+#include "pico/stdlib.h"
+#include "hardware/i2c.h"
+#include "wiipad.h"
+
+#if WII_PIN_SDA >= 0 and WII_PIN_SCL >= 0
+
+void wiipad_begin(void) {
+    i2c_init(WII_I2C, 400000);
+    gpio_set_function(WII_PIN_SDA, GPIO_FUNC_I2C);
+    gpio_set_function(WII_PIN_SCL, GPIO_FUNC_I2C);
+    gpio_pull_up(WII_PIN_SDA);
+    gpio_pull_up(WII_PIN_SCL);
+    uint8_t init1[] = { 0xF0, 0x55 };
+    uint8_t init2[] = { 0xFB, 0x00 };
+    sleep_ms(100);
+    i2c_write_timeout_us(WII_I2C, WII_ADDR, init1, 2, true, 10000);
+    sleep_ms(100);
+    i2c_write_timeout_us(WII_I2C, WII_ADDR, init2, 2, false, 10000);
+}
+
+uint8_t wiipad_read(void) {
+    static constexpr int LEFT = 1 << 6;
+    static constexpr int RIGHT = 1 << 7;
+    static constexpr int UP = 1 << 4;
+    static constexpr int DOWN = 1 << 5;
+    static constexpr int SELECT = 1 << 2;
+    static constexpr int START = 1 << 3;
+    static constexpr int A = 1 << 0;
+    static constexpr int B = 1 << 1;
+
+    uint8_t v = 0;
+    uint8_t req[] = { 0x00 };
+    uint8_t buf[6];
+    i2c_write_timeout_us(WII_I2C, WII_ADDR, req, 1, true, 1000);
+    sleep_us(200);
+    if (i2c_read_timeout_us(WII_I2C, WII_ADDR, buf, sizeof buf, false, 1000) == sizeof buf) {
+        if (!(buf[5] & 0x01)) v |= UP;
+        if (!(buf[4] & 0x40)) v |= DOWN;
+        if (!(buf[5] & 0x02)) v |= LEFT;
+        if (!(buf[4] & 0x80)) v |= RIGHT;
+        if (!(buf[5] & 0x10)) v |= A;
+        if (!(buf[5] & 0x40)) v |= B;
+        if (!(buf[4] & 0x10)) v |= SELECT;
+        if (!(buf[4] & 0x04)) v |= START;
+    }
+
+    return v;
+}
+
+#endif

--- a/wiipad.cpp
+++ b/wiipad.cpp
@@ -31,9 +31,9 @@ uint8_t wiipad_read(void) {
     uint8_t v = 0;
     uint8_t req[] = { 0x00 };
     uint8_t buf[6];
-    i2c_write_timeout_us(WII_I2C, WII_ADDR, req, 1, true, 1000);
+    i2c_write_timeout_us(WII_I2C, WII_ADDR, req, 1, true, 100000);
     sleep_us(200);
-    if (i2c_read_timeout_us(WII_I2C, WII_ADDR, buf, sizeof buf, false, 1000) == sizeof buf) {
+    if (i2c_read_timeout_us(WII_I2C, WII_ADDR, buf, sizeof buf, false, 100000) == sizeof buf) {
         if (!(buf[5] & 0x01)) v |= UP;
         if (!(buf[4] & 0x40)) v |= DOWN;
         if (!(buf[5] & 0x02)) v |= LEFT;

--- a/wiipad.cpp
+++ b/wiipad.cpp
@@ -5,17 +5,17 @@
 #if WII_PIN_SDA >= 0 and WII_PIN_SCL >= 0
 
 void wiipad_begin(void) {
-    i2c_init(WII_I2C, 400000);
     gpio_set_function(WII_PIN_SDA, GPIO_FUNC_I2C);
     gpio_set_function(WII_PIN_SCL, GPIO_FUNC_I2C);
     gpio_pull_up(WII_PIN_SDA);
     gpio_pull_up(WII_PIN_SCL);
+    i2c_init(WII_I2C, 400000);
     uint8_t init1[] = { 0xF0, 0x55 };
     uint8_t init2[] = { 0xFB, 0x00 };
     sleep_ms(100);
-    i2c_write_timeout_us(WII_I2C, WII_ADDR, init1, 2, true, 10000);
+    i2c_write_timeout_us(WII_I2C, WII_ADDR, init1, 2, true, 100);
     sleep_ms(100);
-    i2c_write_timeout_us(WII_I2C, WII_ADDR, init2, 2, false, 10000);
+    i2c_write_timeout_us(WII_I2C, WII_ADDR, init2, 2, false, 100);
 }
 
 uint8_t wiipad_read(void) {
@@ -31,9 +31,9 @@ uint8_t wiipad_read(void) {
     uint8_t v = 0;
     uint8_t req[] = { 0x00 };
     uint8_t buf[6];
-    i2c_write_timeout_us(WII_I2C, WII_ADDR, req, 1, true, 100000);
+    i2c_write_timeout_us(WII_I2C, WII_ADDR, req, 1, true, 100);
     sleep_us(200);
-    if (i2c_read_timeout_us(WII_I2C, WII_ADDR, buf, sizeof buf, false, 100000) == sizeof buf) {
+    if (i2c_read_timeout_us(WII_I2C, WII_ADDR, buf, sizeof buf, false, 200) == sizeof buf) {
         if (!(buf[5] & 0x01)) v |= UP;
         if (!(buf[4] & 0x40)) v |= DOWN;
         if (!(buf[5] & 0x02)) v |= LEFT;

--- a/wiipad.cpp
+++ b/wiipad.cpp
@@ -5,15 +5,14 @@
 #if WII_PIN_SDA >= 0 and WII_PIN_SCL >= 0
 
 void wiipad_begin(void) {
+    i2c_init(WII_I2C, 400000);
     gpio_set_function(WII_PIN_SDA, GPIO_FUNC_I2C);
     gpio_set_function(WII_PIN_SCL, GPIO_FUNC_I2C);
     gpio_pull_up(WII_PIN_SDA);
     gpio_pull_up(WII_PIN_SCL);
-    i2c_init(WII_I2C, 400000);
     uint8_t init1[] = { 0xF0, 0x55 };
     uint8_t init2[] = { 0xFB, 0x00 };
-    sleep_ms(100);
-    i2c_write_timeout_us(WII_I2C, WII_ADDR, init1, 2, true, 100);
+    i2c_write_timeout_us(WII_I2C, WII_ADDR, init1, 2, false, 100);
     sleep_ms(100);
     i2c_write_timeout_us(WII_I2C, WII_ADDR, init2, 2, false, 100);
 }
@@ -31,9 +30,9 @@ uint8_t wiipad_read(void) {
     uint8_t v = 0;
     uint8_t req[] = { 0x00 };
     uint8_t buf[6];
-    i2c_write_timeout_us(WII_I2C, WII_ADDR, req, 1, true, 100);
+    i2c_write_timeout_us(WII_I2C, WII_ADDR, req, 1, false, 100);
     sleep_us(200);
-    if (i2c_read_timeout_us(WII_I2C, WII_ADDR, buf, sizeof buf, false, 200) == sizeof buf) {
+    if (i2c_read_timeout_us(WII_I2C, WII_ADDR, buf, sizeof buf, false, 600) == sizeof buf) {
         if (!(buf[5] & 0x01)) v |= UP;
         if (!(buf[4] & 0x40)) v |= DOWN;
         if (!(buf[5] & 0x02)) v |= LEFT;

--- a/wiipad.h
+++ b/wiipad.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#define WII_I2C i2c1
+#define WII_ADDR 0x52
+
+extern void wiipad_begin(void);
+extern uint8_t wiipad_read(void);


### PR DESCRIPTION
DO NOT MERGE, doesn’t actually work yet, but asking for insights…

Goal here is both to support a new Adafruit board (Feather RP2040 DVI) AND the ability to use a Wii Classic Controller (or other Nintendo I2C controllers) via the STEMMA connector on this board. SOME of this works; DVI out is working on the Feather, and I can navigate the menu with the controller. BUT…

Selecting a game results in a “red screen of death.” Disable the I2C code and use a regular controller, it works fine. I’m like 93% certain it’s just the code size, that loading a game clobbers the emulator in flash. The I2C code (in wiipad.cpp) is not large, but the i2c functions it invokes probably push something over the limit.

The Feather has 8 MB flash instead of 2 MB. In principle it would seem possible to load game ROMs at a different address that doesn’t overlap the code (if that is indeed what’s happening)…but, to be honest, I’m both a stranger to this project and also not well versed in cmake. If you have ideas on what might be needed to make this work, I can try those things here and will push an update once it’s resolved and known working.

Much appreciated, thank you!