### PR TITLE
NSF playback and FDS settings with various fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ fh.log
 *.nes
 *.fds
 *.wav
+*.nsf
 CMakePresets.json
 /pimoroni-pico/
 # Prerequisites

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 *Zone.Identifier
 fh.log
+*.nes
+*.fds
+*.wav
 CMakePresets.json
 /pimoroni-pico/
 # Prerequisites
@@ -74,8 +77,7 @@ bld/
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/
-*.nes
-*.fds
+
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This release brings improvements to Famicom Disk System support, including the a
 
 **Famicom Disk System**
 
+Note that FDS support requires an RP2350 board with PSRAM and a BIOS file at `/bios/fds-bios.rom`.
+
 - Implement save games for games that support write save data back to disk, like Metroid and Zelda. Saves are stored as `/SAVES/gametitle_fds.sav` [#193](https://github.com/fhoedemakers/pico-infonesPlus/issues/193)
 - Added setting in the options menu to automatically swap disk sides. You can still do this manually via the settings menu if you want.
 - Added support for the FDS sound expansion audio. Audio is not perfect but acceptable. [#195](https://github.com/fhoedemakers/pico-infonesPlus/issues/195)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-This release includes significant improvements to Famicom Disk System support and adds NSF audio playback. The settings interface has been refined for better usability, and several stability issues have been resolved.
+This release brings major improvements to Famicom Disk System support, including the ability to save games back to disk and enhanced FDS expansion audio. It also introduces an NSF audio player. The settings interface has been refined for improved usability, and several stability issues have been fixed.
 
 
 # General Info
@@ -19,6 +19,7 @@ This release includes significant improvements to Famicom Disk System support an
 
 - Implement save games for games that support write save data back to disk, like Metroid and Zelda. Saves are stored as `/SAVES/gametitle_fds.sav`
 - Added setting in the options menu to automatically swap disk sides. You can still do this manually via the settings menu if you want.
+- Added support for the FDS sound expansion audio. 
 
 **NSF playback**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ Note that FDS support requires an RP2350 board with PSRAM and a BIOS file at `/b
 
 - Implement save games for games that support write save data back to disk, like Metroid and Zelda. Saves are stored as `/SAVES/gametitle_fds.sav` [#193](https://github.com/fhoedemakers/pico-infonesPlus/issues/193)
 - Added setting in the options menu to automatically swap disk sides. You can still do this manually via the settings menu if you want.
-- Added support for the FDS sound expansion audio. Audio is not perfect but acceptable. [#195](https://github.com/fhoedemakers/pico-infonesPlus/issues/195)
+
+Audio is not perfect but acceptable.
 
 **NSF playback**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ This release brings major improvements to Famicom Disk System support, including
 
 **Famicom Disk System**
 
-- Implement save games for games that support write save data back to disk, like Metroid and Zelda. Saves are stored as `/SAVES/gametitle_fds.sav`
+- Implement save games for games that support write save data back to disk, like Metroid and Zelda. Saves are stored as `/SAVES/gametitle_fds.sav` [#193](https://github.com/fhoedemakers/pico-infonesPlus/issues/193)
 - Added setting in the options menu to automatically swap disk sides. You can still do this manually via the settings menu if you want.
-- Added support for the FDS sound expansion audio. Audio is not perfect but acceptable.
+- Added support for the FDS sound expansion audio. Audio is not perfect but acceptable. [#195](https://github.com/fhoedemakers/pico-infonesPlus/issues/195)
 
 **NSF playback**
 
@@ -41,7 +41,7 @@ Not all nsf roms can be played and some still sound bad or not at all.
 
 **Famicom Disk System**
 
-- Fix disk error 24 in Metroid and possible in other games too.
+- Fix disk error 24 in Metroid and possible in other games too. [#192](https://github.com/fhoedemakers/pico-infonesPlus/issues/192)
 - Fix for game lock-up in Zelda when moving to the next screen during gameplay.
 
 # v0.40 (This is a re-release of v0.39 with some fixes and improvements)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-This release introduces significant enhancements to Famicom Disk System support and introduces NSF audio playback. The settings interface has been refined for improved usability, and several stability issues have been resolved. 
+This release includes significant improvements to Famicom Disk System support and adds NSF audio playback. The settings interface has been refined for better usability, and several stability issues have been resolved.
 
 
 # General Info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,6 @@ Audio is not perfect but acceptable.
 	- Button2 Stop
 	- Button1 Resume
 
-Not all nsf roms can be played and some still sound bad or not at all.
-
 **Settings menu**
 
 - Better use of screen real estate:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This release includes significant improvements to Famicom Disk System support an
 
 **Famicom Disk System**
 
-- Implement save games for games that support write save data back to disk, like Metroid and Zelda. Saves are stored as /SAVES/gametitle_fds.sav
+- Implement save games for games that support write save data back to disk, like Metroid and Zelda. Saves are stored as `/SAVES/gametitle_fds.sav`
 - Added setting in the options menu to automatically swap disk sides. You can still do this manually via the settings menu if you want.
 
 **NSF playback**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-This release brings major improvements to Famicom Disk System support, including the ability to save games back to disk and enhanced FDS expansion audio. It also introduces an NSF audio player. The settings interface has been refined for improved usability, and several stability issues have been fixed.
+This release brings improvements to Famicom Disk System support, including the ability to save games back to disk and FDS expansion audio. It also introduces an NSF audio player. The settings interface has been refined for improved usability, and several stability issues have been fixed.
 
 
 # General Info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This release brings improvements to Famicom Disk System support, including the a
 Note that FDS support requires an RP2350 board with PSRAM and a BIOS file at `/bios/fds-bios.rom`.
 
 - Implement save games for games that support write save data back to disk, like Metroid and Zelda. Saves are stored as `/SAVES/gametitle_fds.sav` [#193](https://github.com/fhoedemakers/pico-infonesPlus/issues/193)
-- Added setting in the options menu to automatically swap disk sides. You can still do this manually via the settings menu if you want.
+- Added an option to the settings menu to automatically swap disk sides. This setting is disabled by default. When it’s off, you can manually swap disks in-game using SELECT + START.
 
 Audio is not perfect but acceptable.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-Famicom Disk System support with limitations, additional mapper improvements, and native PAL/Dendy frame rates on RP2350 boards.
+Famicom Disk System save games and bug fixes. NSF playback.
 
 # General Info
 
@@ -10,6 +10,38 @@ Famicom Disk System support with limitations, additional mapper improvements, an
 
 [See setup section in readme how to install and wire up](https://github.com/fhoedemakers/pico-infonesPlus#pico-setup)
 
+# v0.41 
+
+## Features
+
+**Famicom Disk System**
+
+- Implement save games for games that support write save data back to disk, like Metroid and Zelda. Saves are stored as /SAVES/gametitle_fds.sav
+- Added setting in the options menu to automatically swap disk sides. You can still do this manually via the settings menu if you want.
+
+**NSF playback**
+
+- Added NSF playback. Emulator can load and play `.nsf` (Nintendo Sound Format) roms.
+- Controls:
+	- LEFT/RIGHT change track
+	- Button2 Stop
+	- Button1 Resume
+Not all nsf roms can be played and some still sound bad or not at all.
+
+**Settings menu**
+
+- Better use of screen real estate:
+	- SAVE / DEFAULT / CANCEL are on the same row.
+	- FG/BG color codes now placed to the left to the color grid.
+
+## Fixes
+
+**Famicom Disk System**
+
+- Fix disk error 24 in Metroid and possible in other games too.
+- Fix for game lock-up in Zelda when moving to the next screen during gameplay.
+
+- Games
 # v0.40 (This is a re-release of v0.39 with some fixes and improvements)
 
 - Fix incorrect parsing of region in NES 2.0 header. [#197](https://github.com/fhoedemakers/pico-infonesPlus/issues/197) Thanks to [@Lome-one](https://github.com/Lome-one) for reporting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-This release brings improvements to Famicom Disk System support, including the ability to save games back to disk and FDS expansion audio. It also introduces an NSF audio player. The settings interface has been refined for improved usability, and several issues have been fixed.
+This release brings improvements to Famicom Disk System support, including the ability to save games back to disk and bug fixes for disk errors in Metroid and Zelda. It also introduces an NSF audio player. The settings interface has been refined for improved usability, and several other issues have been fixed.
 
 
 # General Info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
-Famicom Disk System save games and bug fixes. NSF playback.
+This release introduces significant enhancements to Famicom Disk System support and introduces NSF audio playback. The settings interface has been refined for improved usability, and several stability issues have been resolved. 
+
 
 # General Info
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-This release brings improvements to Famicom Disk System support, including the ability to save games back to disk and FDS expansion audio. It also introduces an NSF audio player. The settings interface has been refined for improved usability, and several stability issues have been fixed.
+This release brings improvements to Famicom Disk System support, including the ability to save games back to disk and FDS expansion audio. It also introduces an NSF audio player. The settings interface has been refined for improved usability, and several issues have been fixed.
 
 
 # General Info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ Not all nsf roms can be played and some still sound bad or not at all.
 - Fix disk error 24 in Metroid and possible in other games too. [#192](https://github.com/fhoedemakers/pico-infonesPlus/issues/192)
 - Fix for game lock-up in Zelda when moving to the next screen during gameplay.
 
+## Use of AI
+
+FDS, NSF, additional mappers developed with the help of [Anthropic Claude Opus 4.6](https://www.anthropic.com/claude/opus)
+
 # v0.40 (This is a re-release of v0.39 with some fixes and improvements)
 
 - Fix incorrect parsing of region in NES 2.0 header. [#197](https://github.com/fhoedemakers/pico-infonesPlus/issues/197) Thanks to [@Lome-one](https://github.com/Lome-one) for reporting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Famicom Disk System save games and bug fixes. NSF playback.
 	- LEFT/RIGHT change track
 	- Button2 Stop
 	- Button1 Resume
+
 Not all nsf roms can be played and some still sound bad or not at all.
 
 **Settings menu**
@@ -41,7 +42,6 @@ Not all nsf roms can be played and some still sound bad or not at all.
 - Fix disk error 24 in Metroid and possible in other games too.
 - Fix for game lock-up in Zelda when moving to the next screen during gameplay.
 
-- Games
 # v0.40 (This is a re-release of v0.39 with some fixes and improvements)
 
 - Fix incorrect parsing of region in NES 2.0 header. [#197](https://github.com/fhoedemakers/pico-infonesPlus/issues/197) Thanks to [@Lome-one](https://github.com/Lome-one) for reporting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This release brings major improvements to Famicom Disk System support, including
 
 - Implement save games for games that support write save data back to disk, like Metroid and Zelda. Saves are stored as `/SAVES/gametitle_fds.sav`
 - Added setting in the options menu to automatically swap disk sides. You can still do this manually via the settings menu if you want.
-- Added support for the FDS sound expansion audio. 
+- Added support for the FDS sound expansion audio. Audio is not perfect but acceptable.
 
 **NSF playback**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Note that FDS support requires an RP2350 board with PSRAM and a BIOS file at `/b
 
 Audio is not perfect but acceptable.
 
-**NSF playback**
+**NSF sound playback**
 
 - Added NSF playback. Emulator can load and play `.nsf` (Nintendo Sound Format) roms.
 - Controls:

--- a/README.md
+++ b/README.md
@@ -961,7 +961,7 @@ When prompted to swap disks, use the in-game settings menu:
 ***
 # Playing NSF files
 
-The emulator can play Nintendo Sound Format files. These are roms with the `.nsf` extension. At the moment not all NSF files are playable, and on RP2040, some files may cause red screen flicker.
+The emulator can play Nintendo Sound Format files. These are roms with the `.nsf` extension. At the moment not all NSF files are playable, and on RP2040, some files may cause red screen flicker and no sound.
 
 Each NSF file can have multiple tracks. Loading a `.nsf` rom from the menu will automatically start the first track.  Each track is played for the maximum duration of 3 minutes. Then the next track is played. When there is silence for more than 4 seconds, the next track is played.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 - **Dual Controller Support** – Two simultaneous controllers for multiplayer gameplay ([details](#about-two-player-games))
 - **Save State Management** – Automatic battery-backed SRAM persistence and manual save states
 - **Audio Playback** – WAV format audio playback in the menu (RP2350 only)
-- **Famicom Disk System** – Support for FDS game images with user-supplied BIOS
+- **Famicom Disk System** – Support for FDS game images with user-supplied BIOS. More info on this in the [FDS Games](#famicom-disk-system-fds-games-1) section below.
+- **NSF Playback** – Play NES music files with visual VU-meter overlay. More info on this in the [Playing NSF Files](#playing-nsf-files) section below.
 - **Multi-Region Support** – NTSC, PAL, and Dendy region compatibility
 - **Flexible Hardware** – Compatible with standard DVI/HDMI breakout boards, with optional [custom PCB](#pcb-with-raspberry-pi-pico-or-pico-2) and [3D-printed case](https://github.com/fhoedemakers/pico-infonesPlus#3d-printed-case)
 
@@ -941,6 +942,7 @@ FDS games are supported with the following requirements:
 
 - A BIOS file is required. Place it at `/bios/fds-bios.rom` on the SD card.
 - An RP2350 board with PSRAM is required.
+- You need roms with the `.fds` extension.
 
 FDS games have these features:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 - **WAV Audio Playback** – WAV (`.wav`) format audio playback in the menu (RP2350 only). More info on this in the [WAV Music Playback in Menu](#wav-music-playback-in-menu-rp2350-only) section below.
 - **Flexible Hardware** – [Compatible with standard DVI/HDMI breakout boards](#possible-configurations), with optional [custom PCB](#pcb-with-raspberry-pi-pico-or-pico-2) and [3D-printed case](https://github.com/fhoedemakers/pico-infonesPlus#3d-printed-case)
 
+
+
 ### Regional Support
 
 | Platform | NTSC | PAL | Dendy |

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@
 - **SD Card Menu System** – Browse and launch games from an on-screen menu interface
 - **Dual Controller Support** – Two simultaneous controllers for multiplayer gameplay ([details](#about-two-player-games))
 - **Save State Management** – Automatic battery-backed SRAM persistence and manual save states
-- **Audio Playback** – WAV format audio playback in the menu (RP2350 only)
 - **Famicom Disk System** – Support for FDS game images with user-supplied BIOS. More info on this in the [FDS Games](#famicom-disk-system-fds-games-1) section below.
-- **NSF Playback** – Play NES music files with visual VU-meter overlay. More info on this in the [Playing NSF Files](#playing-nsf-files) section below.
+
 - **Multi-Region Support** – NTSC, PAL, and Dendy region compatibility
+- **NSF Audio Playback** – Play NES music files (`.nsf`) with visual VU-meter overlay. More info on this in the [Playing NSF Files](#playing-nsf-files) section below.
+- **WAV Audio Playback** – WAV format audio playback in the menu (RP2350 only)
 - **Flexible Hardware** – Compatible with standard DVI/HDMI breakout boards, with optional [custom PCB](#pcb-with-raspberry-pi-pico-or-pico-2) and [3D-printed case](https://github.com/fhoedemakers/pico-infonesPlus#3d-printed-case)
 
 ### Regional Support
@@ -969,7 +970,7 @@ When prompted to swap disks, use the in-game settings menu:
 In the settings menu, there is an option **Auto Swap FDS Disks**. This is disabled by default. When enabled, the emulator will automatically swap disks when needed. Note that in some cases you still need to manually swap the disks.
 
 ***
-# Playing NSF files
+# Playing NSF audio files
 
 The emulator can play Nintendo Sound Format files. These are roms with the `.nsf` extension. At the moment not all NSF files are playable.
 
@@ -983,8 +984,6 @@ Each NSF file can have multiple tracks. Loading a `.nsf` rom from the menu will 
 - Select + Start: Back to the menu.
 
 <img width="1920" height="1080" alt="Screenshot 2026-05-04 10-12-59" src="https://github.com/user-attachments/assets/6e6a954e-e58f-48c3-9989-ea5482f3e992" />
-
-
 
 ***
 
@@ -1049,7 +1048,7 @@ Save States should work for  mapper 0,1,2,3 and 4. Other mappers may or may not 
 
 ***
 
-# Music Playback in menu (RP2350 Only)
+# WAV Music Playback in menu (RP2350 Only)
 
 The menu allows you to play music files. Files must meet the following requirements:
 
@@ -1283,10 +1282,11 @@ Mesen: https://github.com/SourMesen/Mesen2 used as basis for:
 
 [Anthropic Claude Opus 4.6](https://www.anthropic.com/claude/opus) assisted with: 
 
-- Famicom Disk System (FDS) support, including expansion audio support.
-- NES mapper 5 (MMC5)
+- Famicom Disk System (FDS) support.
+- mapper 5 (MMC5)
 - mapper 24 (VRC6a)
 - mapper 30
+- mapper 85
 - fixes in other mappers
 - NSF player support
 - general code optimizations and bug fixes

--- a/README.md
+++ b/README.md
@@ -184,14 +184,17 @@ Without PSRAM, selecting a game ROM triggers a reboot: the ROM is written to fla
 With PSRAM, this step is no longer needed. Games are loaded directly from the SD card into PSRAM and executed immediately, resulting in much faster startup times.
 
 
-> [!NOTE]
-> The Waveshare RP2350-PiZero requires a Winbond flash chip for PSRAM to function correctly with the emulator.  However, some boards ship with a flash chip from a different manufacturer, causing the emulator to crash.  See [#191](https://github.com/fhoedemakers/pico-infonesPlus/issues/191) See issue [#191](https://github.com/fhoedemakers/pico-infonesPlus/issues/191).  In this scenario the board can only run the emulator if no PSRAM is installed.
 
 | Board | PSRAM Included |
 |:--|:--|
-| [Waveshare RP2350-PiZero](https://www.waveshare.com/rp2350-pizero.htm) | No – optional, must be soldered ([PSRAM module](https://www.adafruit.com/product/4677)) |
+| [Waveshare RP2350-PiZero](https://www.waveshare.com/rp2350-pizero.htm) | No – optional, must be soldered ([PSRAM module](https://www.adafruit.com/product/4677)) See also issue [#191](https://github.com/fhoedemakers/pico-infonesPlus/issues/191) |
 | [Adafruit Metro RP2350 with PSRAM](https://www.adafruit.com/product/6267) | Yes – pre-installed |
 | [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2) | Yes – pre-installed |
+| [Adafruit Fruit Jam](https://www.adafruit.com/product/6200) | Yes - pre-installed |
+
+> [!NOTE]
+> The Waveshare RP2350-PiZero requires a Winbond flash chip for PSRAM to function correctly with the emulator.  However, some boards ship with a flash chip from a different manufacturer, causing the emulator to crash.  See issue [#191](https://github.com/fhoedemakers/pico-infonesPlus/issues/191).  In this scenario the board can only run the emulator if no PSRAM is installed.
+
 
 
 ***

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ See downloads in the releases page for the correct binary to use with these boar
 ***
 
 ## Gamecontroller support
-Depending on the hardware configuration, the emulator supports these gamecontrollers. An USB-Y cable is needed to both connect power and a gamecontroller to the usb-port.
+Depending on the hardware configuration, the emulator supports these gamecontrollers. In some configurations, an USB-Y cable is needed to both connect power and a gamecontroller to the usb-port.
 
 ### USB  game Controllers
 - Sony Dual Shock 4
@@ -146,7 +146,7 @@ For more info, see [pio_usb.md](pio_usb.md).
 
 ### Legacy controllers
 - One or optional two original NES controllers for two player games.  In some configurations, soldering is required.
-- WII-classic controller: Adafruit Feather RP2040 and WaveShare RP2040 Pi-Zero boards only
+- WII-classic controller: Adafruit Feather RP2040, WaveShare RP2040 Pi-Zero, Adafruit Metro RP2350, Adafruit Fruit Jam boards only
       
 Parts list for legacy controllers
   * NES Controller. A second controller port and controller is optional and only needed if you want to play two player games using NES controllers. Two player games can also be played with a USB controller and a NES controller.
@@ -183,6 +183,9 @@ Without PSRAM, selecting a game ROM triggers a reboot: the ROM is written to fla
 
 With PSRAM, this step is no longer needed. Games are loaded directly from the SD card into PSRAM and executed immediately, resulting in much faster startup times.
 
+
+> [!NOTE] The Waveshare RP2350-PiZero requires a Winbond flash chip for PSRAM to function correctly with the emulator.  However, some boards ship with a flash chip from a different manufacturer, causing the emulator to crash.  See [#191](https://github.com/fhoedemakers/pico-infonesPlus/issues/191)
+
 | Board | PSRAM Included |
 |:--|:--|
 | [Waveshare RP2350-PiZero](https://www.waveshare.com/rp2350-pizero.htm) | No – optional, must be soldered ([PSRAM module](https://www.adafruit.com/product/4677)) |
@@ -193,7 +196,6 @@ With PSRAM, this step is no longer needed. Games are loaded directly from the SD
 ***
 
 ## Warning
-Repeatedly flashing your Pico will eventually wear out the flash memory. 
 
 The emulator overclocks the Pico in order to get the emulator working fast enough. Overclocking can reduce the Pico's lifespan.
 

--- a/README.md
+++ b/README.md
@@ -958,6 +958,10 @@ When prompted to swap disks, use the in-game settings menu:
 3. Press **LEFT/RIGHT** to choose the disk side.
 4. Press **Button2** to confirm and return.
 
+### Auto Swapping disks
+
+In the settings menu, there is an option **Auto Swap FDS Disks**. This is disabled by default. When enabled, the emulator will automatically swap disks when needed. Note that in some cases you still need to manually swap the disks.
+
 ***
 # Playing NSF files
 

--- a/README.md
+++ b/README.md
@@ -956,6 +956,26 @@ When prompted to swap disks, use the in-game settings menu:
 3. Press **LEFT/RIGHT** to choose the disk side.
 4. Press **Button2** to confirm and return.
 
+***
+# Playing NSF files
+
+The emulator can play Nintendo Sound Format files. These are roms with the `.nsf` extension. At the moment not all NSF files are playable, and on RP2040, some files may cause red screen flicker.
+
+Each NSF file can have multiple tracks. Loading a `.nsf` rom from the menu will automatically start the first track.  Each track is played for the maximum duration of 3 minutes. Then the next track is played. When there is silence for more than 4 seconds, the next track is played.
+
+**Controls**
+
+- Right/Left: Next/Previous track.
+- Button1: Stop Playback
+- Button2: Resume playback.
+- Select + Start: Back to the menu.
+
+<img width="1920" height="1080" alt="Screenshot 2026-05-04 10-12-59" src="https://github.com/user-attachments/assets/6e6a954e-e58f-48c3-9989-ea5482f3e992" />
+
+
+
+***
+
 # Gamepad and keyboard usage
 
 |     | (S)NES | Genesis | XInput | Dual Shock/Sense | 

--- a/README.md
+++ b/README.md
@@ -1235,7 +1235,16 @@ lwmem: https://github.com/MaJerle/lwmem
 
 Mesen NES rom database: https://github.com/SourMesen/Mesen2
 
-[Anthropic Claude Opus 4.6](https://www.anthropic.com/claude/opus): Assisted with NES mapper 5 (MMC5), mapper 24 (VRC6a), mapper 30, fixes in other mappers, and with general code optimizations and bug fixes.
+[Anthropic Claude Opus 4.6](https://www.anthropic.com/claude/opus) assisted with: 
+
+- Famicom Disk System (FDS) support
+- NES mapper 5 (MMC5)
+- mapper 24 (VRC6a)
+- mapper 30
+- fixes in other mappers
+- NSF player support
+- general code optimizations and bug fixes
+
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -1260,7 +1260,11 @@ PSRAM: https://github.com/AndrewCapon/PicoPlusPsram
 
 lwmem: https://github.com/MaJerle/lwmem
 
-Mesen NES rom database: https://github.com/SourMesen/Mesen2
+Mesen: https://github.com/SourMesen/Mesen2 used as basis for:
+
+- NES rom database 
+- FDS implementation
+- NSF playback.
 
 [Anthropic Claude Opus 4.6](https://www.anthropic.com/claude/opus) assisted with: 
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Click on the link below for your specific board configuration:
 > This board is discontinued and no longer sold by Pimoroni
 
 ### materials needed
-- Raspberry Pi Pico or Pico 2 with soldered male headers.
+- Raspberry Pi Pico, Pico 2 or [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) with soldered male headers.
 - [Pimoroni Pico DV Demo Base](https://shop.pimoroni.com/products/pimoroni-pico-dv-demo-base?variant=39494203998291).
 - [Micro usb to usb OTG Cable](https://a.co/d/dKW6WGe)
 - Controllers (Depending on what you have)
@@ -691,7 +691,7 @@ Please keep the following in mind:
 - One of these Waveshare boards:
   - [Waveshare RP2040-PiZero Development Board](https://www.waveshare.com/rp2040-pizero.htm).
   - [Waveshare RP2350-PiZero Development Board](https://www.waveshare.com/rp2350-pizero.htm).
-    - Optional: [PSRAM chip](https://www.adafruit.com/product/4677) When installed, the emulator loads ROMs from PSRAM instead of flash memory for significantly faster performance. Fully functional even without PSRAM
+    - Optional: [PSRAM chip](https://www.adafruit.com/product/4677) When installed, the emulator loads ROMs from PSRAM instead of flash memory for significantly faster performance. Fully functional even without PSRAM. There is an issue with boards usings flash chips from another brand than Winbond, where the PSRAM is not working. See [#191](https://github.com/fhoedemakers/pico-infonesPlus/issues/191)
 - [USB-C to USB-A cable](https://a.co/d/2i7rJid) for flashing the uf2 onto the board.
 - USB-C Power supply. Connect to the port labelled USB, not PIO-USB. See note below.
 - [Mini HDMI to HDMI Cable](https://a.co/d/5BZg3Z6).
@@ -824,7 +824,7 @@ When ordering, simply upload the zip file containing the gerber design.  This fi
 > If you are looking for the previous design (v0.2). You can find it [here](PCB/v0.2)
 
 > [!NOTE]
-> It seems that sellers on AliExpress have copied the PCB design and are selling pre-populated PCB's. For questions about those boards, please contact the seller on AliExpress.
+> Sellers on AliExpress have copied the PCB design and are selling pre-populated PCB's. For questions about those boards, please contact the seller on AliExpress.
 
 Other materials needed:
 
@@ -944,32 +944,6 @@ Download the metadata pack from the [releases page](https://github.com/fhoedemak
 
 <img width="1920" height="1080" alt="Screenshot 2025-08-25 15-43-24" src="https://github.com/user-attachments/assets/7aa98825-e3b1-4c7a-ba13-80e04929a27d" />
 
-# Famicom Disk System (FDS) Games
-
-FDS games are supported with the following requirements:
-
-- A BIOS file is required. Place it at `/bios/fds-bios.rom` on the SD card.
-- An RP2350 board with PSRAM is required.
-- You need roms with the `.fds` extension.
-
-FDS games have these features:
-
-- For games that support write save data back to disk, you must go back to the menu to save the game. Saves are written to `/saves/gamename_fds.sav`. Save states are not supported for FDS games.
-- Audio is not perfect but acceptable. 
-  
-### Swapping Disks
-
-When prompted to swap disks, use the in-game settings menu:
-
-1. Press **SELECT + START** to open the settings menu.
-2. Select the first option to change the disk.
-3. Press **LEFT/RIGHT** to choose the disk side.
-4. Press **Button2** to confirm and return.
-
-### Auto Swapping disks
-
-In the settings menu, there is an option **Auto Swap FDS Disks**. This is disabled by default. When enabled, the emulator will automatically swap disks when needed. Note that in some cases you still need to manually swap the disks.
-
 ***
 
 # Gamepad and keyboard usage
@@ -1032,6 +1006,35 @@ Save States should work for  mapper 0,1,2,3 and 4. Other mappers may or may not 
   The mapper number is also shown in the Save State screen.
 
 ***
+
+# Famicom Disk System (FDS) Games
+
+FDS games are supported with the following requirements:
+
+- A BIOS file is required. Place it at `/bios/fds-bios.rom` on the SD card.
+- An RP2350 board with PSRAM is required.
+- You need roms with the `.fds` extension.
+
+FDS games have these features:
+
+- For games that support write save data back to disk, you must go back to the menu to save the game. Saves are written to `/saves/gamename_fds.sav`. Save states are not supported for FDS games.
+- Audio is not perfect but acceptable. 
+  
+### Swapping Disks
+
+When prompted to swap disks, use the in-game settings menu:
+
+1. Press **SELECT + START** to open the settings menu.
+2. Select the first option to change the disk.
+3. Press **LEFT/RIGHT** to choose the disk side.
+4. Press **Button2** to confirm and return.
+
+### Auto Swapping disks
+
+In the settings menu, there is an option **Auto Swap FDS Disks**. This is disabled by default. When enabled, the emulator will automatically swap disks when needed. Note that in some cases you still need to manually swap the disks.
+
+***
+
 # Playing NSF audio files
 
 The emulator can play Nintendo Sound Format files. These are roms with the `.nsf` extension. This works on both the RP2040 and RP2350 boards.
@@ -1283,7 +1286,7 @@ Mesen: https://github.com/SourMesen/Mesen2 used as basis for:
 
 [Anthropic Claude Opus 4.6](https://www.anthropic.com/claude/opus) assisted with: 
 
-- Famicom Disk System (FDS) support.
+- Famicom Disk System (FDS) support
 - mapper 5 (MMC5)
 - mapper 24 (VRC6a)
 - mapper 30

--- a/README.md
+++ b/README.md
@@ -965,7 +965,7 @@ In the settings menu, there is an option **Auto Swap FDS Disks**. This is disabl
 ***
 # Playing NSF files
 
-The emulator can play Nintendo Sound Format files. These are roms with the `.nsf` extension. At the moment not all NSF files are playable, and on RP2040, some files may cause red screen flicker and no sound.
+The emulator can play Nintendo Sound Format files. These are roms with the `.nsf` extension. At the moment not all NSF files are playable.
 
 Each NSF file can have multiple tracks. Loading a `.nsf` rom from the menu will automatically start the first track.  Each track is played for the maximum duration of 3 minutes. Then the next track is played. When there is silence for more than 4 seconds, the next track is played.
 
@@ -1159,16 +1159,17 @@ Alternatively, you can use the [bld.sh](bld.sh) shell script:
 ```
 Build script for the piconesPlus project
 
-Usage: ./pico_shared/bld.sh [-d] [-2 | -r] [-w] [-u] [-m] [-t path to toolchain] [ -p nprocessors] [-c <hwconfig>]
+Usage: ./pico_shared/bld.sh [-d] [-2 | -r] [-w] [-u] [-m] [-D] [-t path to toolchain] [ -p nprocessors] [-c <hwconfig>]
 Options:
   -d: build in DEBUG configuration
   -2: build for Pico 2 board (RP2350)
   -r: build for Pico 2 board (RP2350) with riscv core
-  -u: enable PIO USB support (default is disabled, RP2350 only)
+  -u: enable PIO USB support (RP2350 only) disabled by default except for Waveshare RP2350-PiZero and Adafruit Fruit Jam.
   -w: build for Pico_w or Pico2_w
   -t <path to riscv toolchain>: only needed for riscv, specify the path to the riscv toolchain bin folder
      Default is $PICO_SDK_PATH/toolchain/RISCV_RPI_2_0_0_2/bin
   -p <nprocessors>: specify the number of processors to use for the build
+  -D Force DVI over HSTX.
   -c <hwconfig>: specify the hardware configuration
      1: Pimoroni Pico DV Demo Base (Default)
      2: Breadboard with Adafruit AdaFruit DVI Breakout Board and AdaFruit MicroSD card breakout board
@@ -1177,6 +1178,14 @@ Options:
      4: Waveshare RP2040-PiZero
      5: Adafruit Metro RP2350 (latest branch of TinyUSB is required for this board)
      6: Waveshare RP2040-Zero/RP2350-Zero with custom PCB
+     7: WaveShare RP2350-PiZero - PIO USB enabled,  -u implied.
+     8: Adafruit Fruit Jam - PIO USB enabled, -u implied.
+     9: WaveShare RP2350-USBA - PIO USB enabled, -u implied.
+     10: Spotpear HDMI board. https://spotpear.com/index/product/detail/id/1207.html
+     11: RP2350-USB-A - OLD config with different SD pins. Deprecated, do not use.
+     12: Murmulator M1
+     13: Murmulator M2 (rp2350 only)
+     14: Adafruit Feather RP2350 with TLV320DAC3100 I2S DAC and sdcard breakout board and PIO USB.
   -m: Run cmake only, do not build the project
   -h: display this help
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ Without PSRAM, selecting a game ROM triggers a reboot: the ROM is written to fla
 With PSRAM, this step is no longer needed. Games are loaded directly from the SD card into PSRAM and executed immediately, resulting in much faster startup times.
 
 
-> [!NOTE] The Waveshare RP2350-PiZero requires a Winbond flash chip for PSRAM to function correctly with the emulator.  However, some boards ship with a flash chip from a different manufacturer, causing the emulator to crash.  See [#191](https://github.com/fhoedemakers/pico-infonesPlus/issues/191)
+> [!NOTE]
+> The Waveshare RP2350-PiZero requires a Winbond flash chip for PSRAM to function correctly with the emulator.  However, some boards ship with a flash chip from a different manufacturer, causing the emulator to crash.  See [#191](https://github.com/fhoedemakers/pico-infonesPlus/issues/191) See issue [#191](https://github.com/fhoedemakers/pico-infonesPlus/issues/191).  In this scenario the board can only run the emulator if no PSRAM is installed.
 
 | Board | PSRAM Included |
 |:--|:--|

--- a/README.md
+++ b/README.md
@@ -937,15 +937,16 @@ Download the metadata pack from the [releases page](https://github.com/fhoedemak
 
 # Famicom Disk System (FDS) Games
 
-FDS games are supported with the following limitations:
+FDS games are supported with the following requirements:
 
 - A BIOS file is required. Place it at `/bios/fds-bios.rom` on the SD card.
 - An RP2350 board with PSRAM is required.
-- Games that save data to disk may not work correctly or at all. (Zelda, Metroid)
-- Expansion audio is not supported.
 
-See [#192](https://github.com/fhoedemakers/pico-infonesPlus/issues/192), [#193](https://github.com/fhoedemakers/pico-infonesPlus/issues/193), [#194](https://github.com/fhoedemakers/pico-infonesPlus/issues/194), [#195](https://github.com/fhoedemakers/pico-infonesPlus/issues/195) for issues regarding to FDS.
+FDS games have these features:
 
+- For games that support write save data back to disk, you must go back to the menu to save the game. Saves are written to `/saves/gamename_fds.sav`. Save states are not supported for FDS games. 
+- Expansion audio is supported. Audio is not perfect but acceptable. 
+  
 ### Swapping Disks
 
 When prompted to swap disks, use the in-game settings menu:
@@ -1237,7 +1238,7 @@ Mesen NES rom database: https://github.com/SourMesen/Mesen2
 
 [Anthropic Claude Opus 4.6](https://www.anthropic.com/claude/opus) assisted with: 
 
-- Famicom Disk System (FDS) support
+- Famicom Disk System (FDS) support, including expansion audio support.
 - NES mapper 5 (MMC5)
 - mapper 24 (VRC6a)
 - mapper 30

--- a/README.md
+++ b/README.md
@@ -946,8 +946,8 @@ FDS games are supported with the following requirements:
 
 FDS games have these features:
 
-- For games that support write save data back to disk, you must go back to the menu to save the game. Saves are written to `/saves/gamename_fds.sav`. Save states are not supported for FDS games. 
-- Expansion audio is supported. Audio is not perfect but acceptable. 
+- For games that support write save data back to disk, you must go back to the menu to save the game. Saves are written to `/saves/gamename_fds.sav`. Save states are not supported for FDS games.
+- Audio is not perfect but acceptable. 
   
 ### Swapping Disks
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 - **Famicom Disk System** – Support for FDS game images with user-supplied BIOS. More info on this in the [FDS Games](#famicom-disk-system-fds-games-1) section below.
 
 - **Multi-Region Support** – NTSC, PAL, and Dendy region compatibility
-- **NSF Audio Playback** – Play NES music files (`.nsf`) with visual VU-meter overlay. More info on this in the [Playing NSF Files](#playing-nsf-files) section below.
-- **WAV Audio Playback** – WAV format audio playback in the menu (RP2350 only)
-- **Flexible Hardware** – Compatible with standard DVI/HDMI breakout boards, with optional [custom PCB](#pcb-with-raspberry-pi-pico-or-pico-2) and [3D-printed case](https://github.com/fhoedemakers/pico-infonesPlus#3d-printed-case)
+- **NSF Audio Playback** – Play NES music files (`.nsf`) with visual VU-meter overlay. More info on this in the [Playing NSF Audio Files](#playing-nsf-audio-files) section below.
+- **WAV Audio Playback** – WAV (`.wav`) format audio playback in the menu (RP2350 only). More info on this in the [WAV Music Playback in Menu](#wav-music-playback-in-menu-rp2350-only) section below.
+- **Flexible Hardware** – [Compatible with standard DVI/HDMI breakout boards](#possible-configurations), with optional [custom PCB](#pcb-with-raspberry-pi-pico-or-pico-2) and [3D-printed case](https://github.com/fhoedemakers/pico-infonesPlus#3d-printed-case)
 
 ### Regional Support
 
@@ -970,22 +970,6 @@ When prompted to swap disks, use the in-game settings menu:
 In the settings menu, there is an option **Auto Swap FDS Disks**. This is disabled by default. When enabled, the emulator will automatically swap disks when needed. Note that in some cases you still need to manually swap the disks.
 
 ***
-# Playing NSF audio files
-
-The emulator can play Nintendo Sound Format files. These are roms with the `.nsf` extension. At the moment not all NSF files are playable.
-
-Each NSF file can have multiple tracks. Loading a `.nsf` rom from the menu will automatically start the first track.  Each track is played for the maximum duration of 3 minutes. Then the next track is played. When there is silence for more than 4 seconds, the next track is played.
-
-**Controls**
-
-- Right/Left: Next/Previous track.
-- Button1: Stop Playback
-- Button2: Resume playback.
-- Select + Start: Back to the menu.
-
-<img width="1920" height="1080" alt="Screenshot 2026-05-04 10-12-59" src="https://github.com/user-attachments/assets/6e6a954e-e58f-48c3-9989-ea5482f3e992" />
-
-***
 
 # Gamepad and keyboard usage
 
@@ -1045,6 +1029,22 @@ Save States should work for  mapper 0,1,2,3 and 4. Other mappers may or may not 
   - https://nesdir.github.io/mapper4.html
 
   The mapper number is also shown in the Save State screen.
+
+***
+# Playing NSF audio files
+
+The emulator can play Nintendo Sound Format files. These are roms with the `.nsf` extension. This works on both the RP2040 and RP2350 boards.
+
+Each NSF file can have multiple tracks. Loading a `.nsf` rom from the menu will automatically start the first track.  Each track is played for the maximum duration of 3 minutes. Then the next track is played. When there is silence for more than 4 seconds, the next track is played.
+
+**Controls**
+
+- Right/Left: Next/Previous track.
+- Button1: Stop Playback
+- Button2: Resume playback.
+- Select + Start: Back to the menu.
+
+<img width="1920" height="1080" alt="Screenshot 2026-05-04 10-12-59" src="https://github.com/user-attachments/assets/6e6a954e-e58f-48c3-9989-ea5482f3e992" />
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 - **Dual Controller Support** – Two simultaneous controllers for multiplayer gameplay ([details](#about-two-player-games))
 - **Save State Management** – Automatic battery-backed SRAM persistence and manual save states
 - **Famicom Disk System** – Support for FDS game images with user-supplied BIOS. More info on this in the [FDS Games](#famicom-disk-system-fds-games-1) section below.
-
 - **Multi-Region Support** – NTSC, PAL, and Dendy region compatibility
 - **NSF Audio Playback** – Play NES music files (`.nsf`) with visual VU-meter overlay. More info on this in the [Playing NSF Audio Files](#playing-nsf-audio-files) section below.
 - **WAV Audio Playback** – WAV (`.wav`) format audio playback in the menu (RP2350 only). More info on this in the [WAV Music Playback in Menu](#wav-music-playback-in-menu-rp2350-only) section below.

--- a/infones/CMakeLists.txt
+++ b/infones/CMakeLists.txt
@@ -7,6 +7,7 @@ INTERFACE
     InfoNES.cpp
     InfoNES_Region.cpp
     InfoNES_FDS.cpp
+    InfoNES_NSF.cpp
     K6502.cpp
 )
 

--- a/infones/InfoNES.cpp
+++ b/infones/InfoNES.cpp
@@ -860,7 +860,12 @@ int __not_in_flash_func(InfoNES_HSync)()
     if (PPU_Scanline >= 4 && PPU_Scanline < 240 - 4)
     {
       InfoNES_PreDrawLine(PPU_Scanline);
-      InfoNES_DrawLine();
+      /* NSF mode has no PPU work — InfoNES_PostDrawLine paints the
+         NSF VU-meter overlay over the line buffer, so skipping the
+         PPU pixel pipeline buys back a large slice of CPU time
+         (Akumajou1.nsf and other heavy NSFs). */
+      if (!IsNSF)  
+        InfoNES_DrawLine();
       InfoNES_PostDrawLine(PPU_Scanline);
     }
     // todo: 描画しないラインにもスプライトオーバーレジスタとかは反映する必要がある

--- a/infones/InfoNES.cpp
+++ b/infones/InfoNES.cpp
@@ -39,6 +39,7 @@
 #include "InfoNES_System.h"
 #include "InfoNES_Mapper.h"
 #include "InfoNES_pAPU.h"
+#include "InfoNES_NSF.h"
 #include "K6502.h"
 #include <assert.h>
 #include <pico.h>
@@ -470,6 +471,15 @@ int InfoNES_Reset()
     ROM_Trainer = 0;
     ROM_FourScr = 0;
   }
+  else if (IsNSF)
+  {
+    // Nintendo Sound Format: dispatch through synthetic mapper 31.
+    MapperNo = 31;
+    ROM_Mirroring = 0;
+    ROM_SRAM = 0;
+    ROM_Trainer = 0;
+    ROM_FourScr = 0;
+  }
   else
   {
     // Mapper Number is 8bits. Always use lower 4bits of byInfo2 for compatibility with old ROMs.
@@ -555,6 +565,12 @@ int InfoNES_Reset()
   /*-------------------------------------------------------------------*/
 
   K6502_Reset();
+
+  // NSF: override CPU state after reset (A=track, X=region, SP=$FD, PC=$4100)
+  if (IsNSF)
+  {
+    nsfSetupCpuState();
+  }
 
   // Successful
   return 0;

--- a/infones/InfoNES.h
+++ b/infones/InfoNES.h
@@ -309,6 +309,9 @@ extern BYTE ROM_FourScr;
    Set by parseROM in main before InfoNES_Reset. RP2350 + PSRAM only. */
 extern bool IsFDS;
 
+/* True when the loaded image is an NSF (Nintendo Sound Format) file. */
+extern bool IsNSF;
+
 /*-------------------------------------------------------------------*/
 /*  Function prototypes                                              */
 /*-------------------------------------------------------------------*/

--- a/infones/InfoNES_FDS.cpp
+++ b/infones/InfoNES_FDS.cpp
@@ -1621,17 +1621,17 @@ void __not_in_flash_func(fdsRenderAudio)(unsigned int n)
 
     /* Point-sample the output ONCE per sample period using Mesen2's
        formula: (waveTable[pos] * gain * volTable) / 1152, range 0..63.
-       Boost ×2 to match Mesen2's default FDS channel gain (~2.4×):
-       real Famicom FDS audio is significantly louder than the internal
-       APU, especially noticeable in bass-heavy intros (e.g. Metroid).
-       Output range 0..126 with the mixer's ×18 gives peak 2268, about
-       1.5× a full-volume pulse channel — matches reference recordings. */
+       Boost ×1.5 to give more weight to FDS audio (real Famicom FDS is
+       louder than internal APU). ×2 would clip on bass-heavy passages
+       when summed with pulse/triangle through the int16 DVI gain stage;
+       ×1.5 gives audible bass without distortion. Final range 0..94. */
     BYTE out = 0;
     if (!fds_wave_write_enabled)
     {
       unsigned int gain = fds_vol_gain < 32 ? fds_vol_gain : 32;
       unsigned int level = gain * FdsWaveVolumeTable[fds_master_volume];
-      out = (BYTE)((((unsigned int)fds_wave_table[fds_wave_position] * level) / 1152) * 2);
+      unsigned int raw = ((unsigned int)fds_wave_table[fds_wave_position] * level) / 1152;
+      out = (BYTE)((raw * 3) / 2);
     }
     fds_wave_buffer[i] = out;
   }

--- a/infones/InfoNES_FDS.cpp
+++ b/infones/InfoNES_FDS.cpp
@@ -18,6 +18,7 @@
 #include "FrensHelpers.h"
 #include "ff.h"
 #include "K6502.h"
+#include "settings.h"
 
 /*-------------------------------------------------------------------*/
 /*  FDS state                                                        */
@@ -98,8 +99,7 @@ static int   fds_pending_side  = -1;
 static bool  fds_auto_insert_enabled = true;
 /* User-facing setting: when false, the entire auto-insert mechanism
    (auto-eject, auto-side-switch, $E445 hook) is disabled.
-   Configurable via settings menu; default = off. */
-bool FDS_AutoInsertEnabled = false;
+   Configurable via settings menu; reads directly from settings.flags.autoSwapFDS. */
 static int   fds_4032_read_count     = 0;
 static int   fds_last_read_hsync     = 0;  /* hsync tick of last $4032 read */
 static int   fds_hsync_counter       = 0;  /* monotonic hsync counter */

--- a/infones/InfoNES_FDS.cpp
+++ b/infones/InfoNES_FDS.cpp
@@ -15,7 +15,10 @@
 #include "InfoNES_FDS.h"
 #include "InfoNES.h"
 #include "InfoNES_System.h"
+#include "InfoNES_pAPU.h"
 #include "FrensHelpers.h"
+
+extern unsigned int ApuCyclesPerSample;
 #include "ff.h"
 #include "K6502.h"
 #include "settings.h"
@@ -196,6 +199,184 @@ static inline void fdsClearDirtyBitmap()
 #endif
 
 static int fds_block_count = 0;
+
+/*-------------------------------------------------------------------*/
+/*  FDS expansion audio state (Mesen2-style wavetable + modulation)  */
+/*-------------------------------------------------------------------*/
+
+/* Wave table: 64 entries, 6-bit each (0-63). */
+static BYTE  fds_wave_table[64] = {0};
+static BYTE  fds_wave_write_enabled = 0; /* $4089 bit 7 */
+static BYTE  fds_wave_position = 0;      /* 0-63 */
+static WORD  fds_wave_overflow = 0;      /* 16-bit phase accumulator */
+
+/* Master volume: 2-bit index into WaveVolumeTable. */
+static BYTE  fds_master_volume = 0;
+static const unsigned int __not_in_flash("fds_audio") FdsWaveVolumeTable[4] = {36, 24, 17, 14};
+
+/* Master envelope speed — BIOS inits to $E8. */
+static BYTE  fds_master_env_speed = 0xE8;
+
+/* Volume envelope ($4080/$4082/$4083). */
+static BYTE  fds_vol_speed     = 0;
+static BYTE  fds_vol_gain      = 0;   /* 0-32 */
+static BYTE  fds_vol_env_off   = 1;   /* $4080 bit 7: 1=envelope disabled */
+static BYTE  fds_vol_increase  = 0;   /* $4080 bit 6: direction */
+static DWORD fds_vol_timer     = 0;
+static WORD  fds_vol_frequency = 0;   /* 12-bit: $4082 low, $4083 low nibble */
+
+/* Waveform control ($4083). */
+static BYTE  fds_disable_envelopes = 0; /* bit 6 */
+static BYTE  fds_halt_waveform     = 0; /* bit 7 */
+
+/* Modulation envelope ($4084). */
+static BYTE  fds_mod_speed     = 0;
+static BYTE  fds_mod_gain      = 0;   /* 0-32 */
+static BYTE  fds_mod_env_off   = 1;
+static BYTE  fds_mod_increase  = 0;
+static DWORD fds_mod_timer     = 0;
+
+/* Modulation unit ($4085-$4088). */
+static WORD  fds_mod_frequency     = 0;   /* 12-bit */
+static BYTE  fds_mod_disabled      = 1;   /* $4087 bit 7 */
+static BYTE  fds_mod_table[64]     = {0}; /* 3-bit entries */
+static BYTE  fds_mod_table_pos     = 0;
+static int8_t fds_mod_counter      = 0;   /* signed 7-bit */
+static WORD  fds_mod_overflow      = 0;   /* 16-bit phase accumulator */
+static int   fds_mod_output        = 0;   /* pitch modulation delta */
+
+/* Audio output buffer — allocated in Map20_Init, freed in pAPUDone. */
+BYTE  ApuFdsEnable = 0;
+BYTE *fds_wave_buffer = nullptr;
+
+/*-------------------------------------------------------------------*/
+/*  FDS audio envelope tick helper (shared by volume + mod channels) */
+/*-------------------------------------------------------------------*/
+static inline bool __not_in_flash_func(fdsTickEnvelope)(BYTE speed, BYTE env_off,
+                                   BYTE increase, BYTE *gain,
+                                   DWORD *timer)
+{
+  if (!env_off && fds_master_env_speed > 0)
+  {
+    if (*timer == 0)
+    {
+      *timer = (DWORD)8 * (speed + 1) * fds_master_env_speed;
+    }
+    (*timer)--;
+    if (*timer == 0)
+    {
+      *timer = (DWORD)8 * (speed + 1) * fds_master_env_speed;
+      if (increase && *gain < 32)
+        (*gain)++;
+      else if (!increase && *gain > 0)
+        (*gain)--;
+      return true;
+    }
+  }
+  return false;
+}
+
+/*-------------------------------------------------------------------*/
+/*  FDS modulation output calculation (Mesen2 algorithm).            */
+/*-------------------------------------------------------------------*/
+static void __not_in_flash_func(fdsUpdateModOutput)(WORD volumePitch)
+{
+  /* Mesen2 "ModChannel::UpdateOutput" — NesDev wiki algorithm.
+     counter = $4085 signed 7-bit, gain = $4084 6-bit unsigned. */
+  int temp = (int)fds_mod_counter * (int)fds_mod_gain;
+  int remainder = temp & 0xF;
+  temp >>= 4;
+  if (remainder > 0 && (temp & 0x80) == 0)
+  {
+    temp += (fds_mod_counter < 0) ? -1 : 2;
+  }
+  if (temp >= 192)
+    temp -= 256;
+  else if (temp < -64)
+    temp += 256;
+
+  temp = (int)volumePitch * temp;
+  remainder = temp & 0x3F;
+  temp >>= 6;
+  if (remainder >= 32)
+    temp += 1;
+
+  fds_mod_output = temp;
+}
+
+/*-------------------------------------------------------------------*/
+/*  FDS modulation counter update (Mesen2 ModChannel::UpdateCounter) */
+/*-------------------------------------------------------------------*/
+static inline void __not_in_flash_func(fdsUpdateModCounter)(int8_t value)
+{
+  fds_mod_counter = value;
+  if (fds_mod_counter >= 64)
+    fds_mod_counter -= 128;
+  else if (fds_mod_counter < -64)
+    fds_mod_counter += 128;
+}
+
+/*-------------------------------------------------------------------*/
+/*  FDS modulator tick — advance mod table on 16-bit overflow.       */
+/*-------------------------------------------------------------------*/
+static const int __not_in_flash("fds_audio") fds_mod_lut[8] = {0, 1, 2, 4, 0x7F, -4, -2, -1};
+#define FDS_MOD_RESET 0x7F
+
+static inline bool __not_in_flash_func(fdsTickModulator)()
+{
+  if (!fds_mod_disabled && fds_mod_frequency > 0)
+  {
+    WORD prev = fds_mod_overflow;
+    fds_mod_overflow += fds_mod_frequency;
+    if (fds_mod_overflow < prev) /* 16-bit overflow */
+    {
+      int offset = fds_mod_lut[fds_mod_table[fds_mod_table_pos]];
+      fdsUpdateModCounter(offset == FDS_MOD_RESET ? 0 :
+                          (int8_t)(fds_mod_counter + offset));
+      fds_mod_table_pos = (fds_mod_table_pos + 1) & 0x3F;
+      return true;
+    }
+  }
+  return false;
+}
+
+/*-------------------------------------------------------------------*/
+/*  fdsResetAudio: clear all FDS audio state. Called from            */
+/*  fdsResetDrive().                                                 */
+/*-------------------------------------------------------------------*/
+void fdsResetAudio()
+{
+  memset(fds_wave_table, 0, sizeof(fds_wave_table));
+  fds_wave_write_enabled = 0;
+  fds_wave_position = 0;
+  fds_wave_overflow = 0;
+
+  fds_master_volume = 0;
+  fds_master_env_speed = 0xE8;
+
+  fds_vol_speed = 0;
+  fds_vol_gain = 0;
+  fds_vol_env_off = 1;
+  fds_vol_increase = 0;
+  fds_vol_timer = 0;
+  fds_vol_frequency = 0;
+
+  fds_disable_envelopes = 0;
+  fds_halt_waveform = 0;
+
+  fds_mod_speed = 0;
+  fds_mod_gain = 0;
+  fds_mod_env_off = 1;
+  fds_mod_increase = 0;
+  fds_mod_timer = 0;
+  fds_mod_frequency = 0;
+  fds_mod_disabled = 1;
+  memset(fds_mod_table, 0, sizeof(fds_mod_table));
+  fds_mod_table_pos = 0;
+  fds_mod_counter = 0;
+  fds_mod_overflow = 0;
+  fds_mod_output = 0;
+}
 
 /*
  *  Linear-walk drive emulation (Mesen2-style).
@@ -942,6 +1123,10 @@ void fdsResetDrive()
 
   fds_write_buf = 0;
   fds_block_count = 0;
+
+  /* Reset FDS expansion audio state. */
+  fdsResetAudio();
+
   FDS_LOG("reset drive\n");
 }
 
@@ -1096,7 +1281,97 @@ void fdsApuWrite(WORD wAddr, BYTE byData)
     break;
 
   default:
-    /* $4040-$4097 (FDS audio) lands here too; phase 7 will handle it. */
+    /*---------------------------------------------------------------*/
+    /*  FDS expansion audio registers ($4040-$408A).                 */
+    /*---------------------------------------------------------------*/
+    if (wAddr >= 0x4040 && wAddr <= 0x407F)
+    {
+      /* Wavetable write — only when wave write is enabled ($4089.7). */
+      if (fds_wave_write_enabled)
+        fds_wave_table[wAddr & 0x3F] = byData & 0x3F;
+    }
+    else
+    {
+      switch (wAddr)
+      {
+      case 0x4080: /* Volume envelope */
+        fds_vol_speed    = byData & 0x3F;
+        fds_vol_increase = (byData >> 6) & 0x01;
+        fds_vol_env_off  = (byData >> 7) & 0x01;
+        /* Writing resets the envelope timer. */
+        fds_vol_timer = (DWORD)8 * (fds_vol_speed + 1) * fds_master_env_speed;
+        if (fds_vol_env_off)
+          fds_vol_gain = fds_vol_speed; /* gain = speed when envelope disabled */
+        break;
+
+      case 0x4082: /* Wave frequency low */
+        fds_vol_frequency = (fds_vol_frequency & 0x0F00) | byData;
+        fdsUpdateModOutput(fds_vol_frequency);
+        break;
+
+      case 0x4083: /* Wave frequency high + control */
+        fds_disable_envelopes = (byData >> 6) & 0x01;
+        fds_halt_waveform     = (byData >> 7) & 0x01;
+        if (fds_halt_waveform)
+          fds_wave_position = 0;
+        if (fds_disable_envelopes)
+        {
+          fds_vol_timer = (DWORD)8 * (fds_vol_speed + 1) * fds_master_env_speed;
+          fds_mod_timer = (DWORD)8 * (fds_mod_speed + 1) * fds_master_env_speed;
+        }
+        fds_vol_frequency = (fds_vol_frequency & 0xFF) | (((WORD)byData & 0x0F) << 8);
+        fdsUpdateModOutput(fds_vol_frequency);
+        break;
+
+      case 0x4084: /* Mod envelope */
+        fds_mod_speed    = byData & 0x3F;
+        fds_mod_increase = (byData >> 6) & 0x01;
+        fds_mod_env_off  = (byData >> 7) & 0x01;
+        fds_mod_timer = (DWORD)8 * (fds_mod_speed + 1) * fds_master_env_speed;
+        if (fds_mod_env_off)
+          fds_mod_gain = fds_mod_speed;
+        fdsUpdateModOutput(fds_vol_frequency);
+        break;
+
+      case 0x4085: /* Mod counter */
+        fdsUpdateModCounter((int8_t)(byData & 0x7F));
+        fdsUpdateModOutput(fds_vol_frequency);
+        break;
+
+      case 0x4086: /* Mod frequency low */
+        fds_mod_frequency = (fds_mod_frequency & 0x0F00) | byData;
+        break;
+
+      case 0x4087: /* Mod frequency high + disable */
+        fds_mod_frequency = (fds_mod_frequency & 0xFF) | (((WORD)byData & 0x0F) << 8);
+        fds_mod_disabled = (byData >> 7) & 0x01;
+        if (fds_mod_disabled)
+          fds_mod_overflow = 0;
+        break;
+
+      case 0x4088: /* Mod table write */
+        /* Only effective when mod unit is disabled ($4087.7). */
+        if (fds_mod_disabled)
+        {
+          fds_mod_table[fds_mod_table_pos & 0x3F] = byData & 0x07;
+          fds_mod_table[(fds_mod_table_pos + 1) & 0x3F] = byData & 0x07;
+          fds_mod_table_pos = (fds_mod_table_pos + 2) & 0x3F;
+        }
+        break;
+
+      case 0x4089: /* Master volume + wave write enable */
+        fds_master_volume = byData & 0x03;
+        fds_wave_write_enabled = (byData >> 7) & 0x01;
+        break;
+
+      case 0x408A: /* Master envelope speed */
+        fds_master_env_speed = byData;
+        break;
+
+      default:
+        break;
+      }
+    }
     break;
   }
 }
@@ -1190,7 +1465,175 @@ BYTE fdsApuRead(WORD wAddr)
     return 0x80;
 
   default:
+    /*---------------------------------------------------------------*/
+    /*  FDS expansion audio read registers.                          */
+    /*---------------------------------------------------------------*/
+    if (wAddr >= 0x4040 && wAddr <= 0x407F)
+    {
+      BYTE v = (BYTE)(wAddr >> 8) & 0xC0; /* open bus high bits */
+      if (fds_wave_write_enabled)
+        v |= fds_wave_table[wAddr & 0x3F];
+      else
+        v |= fds_wave_table[fds_wave_position];
+      return v;
+    }
+    if (wAddr == 0x4090)
+      return ((BYTE)(wAddr >> 8) & 0xC0) | (fds_vol_gain & 0x3F);
+    if (wAddr == 0x4092)
+      return ((BYTE)(wAddr >> 8) & 0xC0) | (fds_mod_gain & 0x3F);
+
     return (BYTE)(wAddr >> 8); /* open bus */
+  }
+}
+
+/*-------------------------------------------------------------------*/
+/*  fdsRenderAudio: produce n audio samples into fds_wave_buffer.    */
+/*  Called from InfoNES_pAPUHsync() once per scanline, typically     */
+/*  producing ~3 samples at 44100 Hz.                                */
+/*                                                                   */
+/*  Adapts Mesen2's per-CPU-cycle ClockAudio() to the batch model    */
+/*  using event-driven simulation: between events (envelope ticks,   */
+/*  modulator ticks), the wave-phase accumulator advances linearly,  */
+/*  so a span of N event-free cycles collapses to a single 32-bit    */
+/*  multiply+shift instead of N per-cycle adds. This is critical for */
+/*  RP2350 performance — the naive per-cycle loop costs ~3ms/frame.  */
+/*                                                                   */
+/*  At sample-period boundaries we point-sample the output using     */
+/*  Mesen2's exact per-cycle formula:                                */
+/*    output = (waveTable[pos] * gain * volTable[masterVol]) / 1152  */
+/*  giving a 0..63 range that's then mixed via wave6 (×18 in mixer). */
+/*-------------------------------------------------------------------*/
+void __not_in_flash_func(fdsRenderAudio)(unsigned int n)
+{
+  if (!fds_wave_buffer) return;
+
+  const unsigned int cyc_per_sample = ApuCyclesPerSample;
+
+  for (unsigned int i = 0; i < n; i++)
+  {
+    unsigned int cycles_left = cyc_per_sample;
+
+    while (cycles_left > 0)
+    {
+      /* Determine how many cycles until the next state-changing event.
+         If no events possible (envelopes off, mod disabled, halted),
+         we can fast-forward the entire remaining sample period. */
+      unsigned int span = cycles_left;
+
+      bool env_active = !fds_halt_waveform && !fds_disable_envelopes &&
+                        fds_master_env_speed > 0;
+
+      if (env_active)
+      {
+        if (!fds_vol_env_off && fds_vol_timer > 0 && fds_vol_timer < span)
+          span = (unsigned int)fds_vol_timer;
+        if (!fds_mod_env_off && fds_mod_timer > 0 && fds_mod_timer < span)
+          span = (unsigned int)fds_mod_timer;
+      }
+
+      /* Modulator overflow event: cycles until 16-bit overflow of
+         (fds_mod_overflow + k * fds_mod_frequency). */
+      bool mod_active = !fds_mod_disabled && fds_mod_frequency > 0;
+      if (mod_active)
+      {
+        unsigned int needed = 0x10000u - (unsigned int)fds_mod_overflow;
+        unsigned int cycles_to_overflow =
+            (needed + fds_mod_frequency - 1) / fds_mod_frequency;
+        if (cycles_to_overflow == 0) cycles_to_overflow = 1;
+        if (cycles_to_overflow < span) span = cycles_to_overflow;
+      }
+
+      if (span == 0) span = 1;
+
+      /* Advance wave-phase accumulator over `span` cycles in one shot. */
+      int delta = (int)fds_vol_frequency + fds_mod_output;
+      if (!fds_halt_waveform && delta > 0)
+      {
+        uint32_t total = (uint32_t)fds_wave_overflow +
+                         (uint32_t)span * (uint32_t)delta;
+        unsigned int carries = total >> 16;
+        fds_wave_overflow = (WORD)(total & 0xFFFF);
+        if (carries)
+          fds_wave_position = (BYTE)((fds_wave_position + carries) & 0x3F);
+      }
+
+      /* Advance modulator overflow accumulator. */
+      if (mod_active)
+      {
+        uint32_t mod_total = (uint32_t)fds_mod_overflow +
+                             (uint32_t)span * (uint32_t)fds_mod_frequency;
+        if (mod_total >= 0x10000u)
+        {
+          /* One overflow per span by construction (span = cycles to
+             next overflow). Tick the modulator. */
+          int offset = fds_mod_lut[fds_mod_table[fds_mod_table_pos]];
+          fdsUpdateModCounter(offset == FDS_MOD_RESET ? 0 :
+                              (int8_t)(fds_mod_counter + offset));
+          fds_mod_table_pos = (fds_mod_table_pos + 1) & 0x3F;
+          fds_mod_overflow = (WORD)(mod_total & 0xFFFF);
+          fdsUpdateModOutput(fds_vol_frequency);
+        }
+        else
+        {
+          fds_mod_overflow = (WORD)mod_total;
+        }
+      }
+
+      /* Advance envelope timers in bulk. */
+      if (env_active)
+      {
+        if (!fds_vol_env_off)
+        {
+          if (fds_vol_timer > span)
+          {
+            fds_vol_timer -= span;
+          }
+          else
+          {
+            /* Timer expires within this span: tick the envelope. */
+            fds_vol_timer = (DWORD)8 * (fds_vol_speed + 1) * fds_master_env_speed;
+            if (fds_vol_increase && fds_vol_gain < 32)
+              fds_vol_gain++;
+            else if (!fds_vol_increase && fds_vol_gain > 0)
+              fds_vol_gain--;
+          }
+        }
+        if (!fds_mod_env_off)
+        {
+          if (fds_mod_timer > span)
+          {
+            fds_mod_timer -= span;
+          }
+          else
+          {
+            fds_mod_timer = (DWORD)8 * (fds_mod_speed + 1) * fds_master_env_speed;
+            if (fds_mod_increase && fds_mod_gain < 32)
+              fds_mod_gain++;
+            else if (!fds_mod_increase && fds_mod_gain > 0)
+              fds_mod_gain--;
+            fdsUpdateModOutput(fds_vol_frequency);
+          }
+        }
+      }
+
+      cycles_left -= span;
+    }
+
+    /* Point-sample the output ONCE per sample period using Mesen2's
+       formula: (waveTable[pos] * gain * volTable) / 1152, range 0..63.
+       Boost ×2 to match Mesen2's default FDS channel gain (~2.4×):
+       real Famicom FDS audio is significantly louder than the internal
+       APU, especially noticeable in bass-heavy intros (e.g. Metroid).
+       Output range 0..126 with the mixer's ×18 gives peak 2268, about
+       1.5× a full-volume pulse channel — matches reference recordings. */
+    BYTE out = 0;
+    if (!fds_wave_write_enabled)
+    {
+      unsigned int gain = fds_vol_gain < 32 ? fds_vol_gain : 32;
+      unsigned int level = gain * FdsWaveVolumeTable[fds_master_volume];
+      out = (BYTE)((((unsigned int)fds_wave_table[fds_wave_position] * level) / 1152) * 2);
+    }
+    fds_wave_buffer[i] = out;
   }
 }
 

--- a/infones/InfoNES_FDS.cpp
+++ b/infones/InfoNES_FDS.cpp
@@ -297,8 +297,14 @@ static bool fdsBuildExpandedBuffer(BYTE *rawDisk, int sides)
 
       if ((DWORD)(srcPos + blockSize) > FDS_SIDE_SIZE) goto side_done;
 
-      /* Record block-start offset (points at first payload byte). */
-      fds_block_starts[s][blkIdx] = writePos - sideStart;
+      /* 0x80 mark byte — Mesen2 inserts this before every block.
+         The FDS BIOS expects to read the mark as the first non-zero
+         byte after a gap (sync mark), then reads the block-type byte
+         that follows.  Without it the BIOS misidentifies blocks. */
+      fds_expanded[writePos++] = FDS_MARK_BYTE;
+
+      /* Record block-start offset (points at 0x80 mark byte). */
+      fds_block_starts[s][blkIdx] = (writePos - 1) - sideStart;
 
       /* Block payload. */
       memcpy(&fds_expanded[writePos], &rawDisk[srcBase + srcPos], (size_t)blockSize);
@@ -318,7 +324,13 @@ static bool fdsBuildExpandedBuffer(BYTE *rawDisk, int sides)
     }
   side_done:
     fds_block_counts[s] = blkIdx;
-    fds_side_sizes[s]   = writePos - sideStart;
+    /* Mesen2 pads each side to at least GetSideCapacity() (65500).
+       This ensures trailing gap space matches a real FDS disk so the
+       BIOS can finish its scan loop before hitting end-of-head. */
+    {
+      DWORD contentSize = writePos - sideStart;
+      fds_side_sizes[s] = contentSize < FDS_SIDE_SIZE ? FDS_SIDE_SIZE : contentSize;
+    }
 
     /* Pad the rest of this side's reserved space so the next side starts
        at a known offset (sideStart + perSideMax). Then bump writePos to
@@ -1101,7 +1113,9 @@ BYTE fdsApuRead(WORD wAddr)
     BYTE r = 0;
     if (fds_timer_irq_pend)   r |= 0x01;
     if (fds_transfer_complete) r |= 0x02;
-    if (fds_end_of_head)      r |= 0x40;
+    /* Mesen2: bit 6 (_endOfHead) is NOT reported in $4030.
+       Reporting it causes games like Zelda to misinterpret the status
+       after reaching end-of-disk and hang instead of retrying. */
     /* Reading $4030 acknowledges the timer IRQ (bit 0) and
        the transfer-complete flag (bit 1), and clears the IRQ line. */
     fds_timer_irq_pend    = 0;
@@ -1328,13 +1342,16 @@ void fdsHsync()
       {
         /* End of disk reached. Mesen2 behavior:
            1. Turn off motor (BIOS will turn it back on to rewind)
-           2. Fire disk IRQ so BIOS's IRQ handler gets called
-           3. Start cooldown before auto-eject detection can fire */
+           2. Fire disk IRQ if enabled ($4025 bit 7)
+           3. Start cooldown before auto-eject detection can fire
+           NOTE: Mesen2 does NOT set transferComplete here — that flag
+           means "a byte is ready in the read buffer", not end-of-head.
+           Setting it caused $4030 to return 0x03 instead of 0x01
+           after the timer fire, confusing the BIOS retry logic. */
         fds_end_of_head = 1;
         fds_motor_on = 0;
         fds_end_of_head_cooldown = FDS_END_OF_HEAD_COOLDOWN_FRAMES;
         fds_disk_read_once = true;
-        fds_transfer_complete = 1;
         if (fds_byte_irq_en) fds_byte_irq_pend = 1;
         FDS_LOG("END of head (side %d, pos=%lu)\n", FDS_CurrentSide,
                 (unsigned long)fds_byte_pos);
@@ -1347,14 +1364,14 @@ void fdsHsync()
       {
         /* READ MODE: gap detection applies.
            Mesen2: when diskReady (scan_start) is false, force gap_ended=0.
-           When true and byte is non-zero while gap_ended==0, set gap_ended=1.
-           Mesen2 suppresses delivery on the gap-end byte because its
-           disk image always has a 0x80 mark byte before each block.
-           Our initial expanded buffer has NO mark bytes, but the BIOS
-           writes 0x80 marks when it writes blocks.  So: if the first
-           non-zero byte is 0x80, silently consume it (mark byte).
-           Otherwise deliver it normally (it IS the block type byte). */
+           When true and byte is non-zero while gap_ended==0, set
+           gap_ended=1 and SUPPRESS the IRQ for that one byte.
+           The expanded buffer includes a 0x80 mark byte before each
+           block (matching Mesen2's AddGaps).  The BIOS expects to
+           read the 0x80 sync mark via polling before the IRQ-driven
+           block-type byte — so we deliver it normally (no skip). */
         BYTE diskByte = side[fds_byte_pos];
+        BYTE need_irq = fds_byte_irq_en;
 
         if (!fds_scan_start)
         {
@@ -1363,23 +1380,16 @@ void fdsHsync()
         else if (diskByte && !fds_gap_ended)
         {
           fds_gap_ended = 1;
+          need_irq = 0;  /* Mesen2: suppress IRQ on gap-end byte */
           FDS_LOG("GAP END: pos=%lu byte=0x%02X\n",
                   (unsigned long)fds_byte_pos, diskByte);
-          if (diskByte == 0x80)
-          {
-            /* Mark byte written by BIOS — consume silently, don't
-               deliver to the game.  Next non-zero byte will be the
-               actual block type. */
-            fds_byte_pos++;
-            continue;
-          }
         }
 
         if (fds_gap_ended)
         {
           fds_transfer_complete = 1;
           fds_read_buf = diskByte;
-          if (fds_byte_irq_en) fds_byte_irq_pend = 1;
+          if (need_irq) fds_byte_irq_pend = 1;
         }
 
         fds_byte_pos++;

--- a/infones/InfoNES_FDS.cpp
+++ b/infones/InfoNES_FDS.cpp
@@ -630,7 +630,7 @@ bool fdsLoadSidecar(const char *path)
   {
     printf("FDS sidecar header mismatch — ignoring.\n");
     f_close(&fil);
-    return false;
+    return true;  /* stale/incompatible sidecar — start fresh */
   }
 
   int numPages = fdsTotalPages();
@@ -639,7 +639,7 @@ bool fdsLoadSidecar(const char *path)
   {
     printf("FDS sidecar bitmap size mismatch — ignoring.\n");
     f_close(&fil);
-    return false;
+    return true;  /* start fresh */
   }
 
   BYTE bm[(FDS_MAX_PAGES + 7) / 8] = {0};

--- a/infones/InfoNES_FDS.cpp
+++ b/infones/InfoNES_FDS.cpp
@@ -70,9 +70,10 @@ static BYTE fds_scanning_started = 0;
 /* Disk transfer state. */
 static DWORD fds_byte_pos        = 0;  /* payload index inside current side */
 static DWORD fds_block_start_pos = 0;  /* byte_pos at start of current block */
-static BYTE  fds_read_buf      = 0;
-static BYTE  fds_byte_irq_pend = 0;
-static BYTE  fds_end_of_head   = 0;
+static BYTE  fds_read_buf        = 0;
+static BYTE  fds_byte_irq_pend   = 0;
+static BYTE  fds_transfer_complete = 0; /* Mesen2 _transferComplete: byte ready in $4031 */
+static BYTE  fds_end_of_head     = 0;
 static WORD  fds_cycle_acc     = 0;
 static int   fds_motor_spinup  = 0;   /* scanlines to wait after motor on */
 
@@ -87,6 +88,35 @@ static BYTE  fds_write_buf     = 0;
 #define FDS_SWAP_EJECT_HSYNCS  (60 * 262)  /* ~1 s of NTSC hsyncs */
 static int   fds_eject_counter = 0;
 static int   fds_pending_side  = -1;
+
+/* Mesen2-style automatic disk-side switching. When the BIOS repeatedly
+   polls $4032 (disk-not-inserted check) in quick succession, it means
+   the game needs a different disk side. We auto-eject, wait ~77 frames,
+   then re-insert. When the BIOS calls $E445 to verify the disk header,
+   we intercept and insert the correct side by matching the 10-byte
+   header buffer against all disk-side headers. */
+static bool  fds_auto_insert_enabled = true;
+/* User-facing setting: when false, the entire auto-insert mechanism
+   (auto-eject, auto-side-switch, $E445 hook) is disabled.
+   Configurable via settings menu; default = off. */
+bool FDS_AutoInsertEnabled = false;
+static int   fds_4032_read_count     = 0;
+static int   fds_last_read_hsync     = 0;  /* hsync tick of last $4032 read */
+static int   fds_hsync_counter       = 0;  /* monotonic hsync counter */
+static int   fds_auto_eject_delay    = -1; /* hsyncs until auto-insert; -1=idle */
+static int   fds_auto_retry_counter  = -1; /* hsyncs to retry if game didn't accept */
+static int   fds_auto_insert_attempts = 0; /* guard against infinite retry */
+static int   fds_previous_side = 0;       /* side before auto-eject (for cycling) */
+/* Mesen2: when the head reaches end-of-disk, a cooldown counter starts.
+   The $4032 polling detection can only fire after this expires. */
+static int   fds_end_of_head_cooldown = 0; /* frames remaining; 0=ready */
+static bool  fds_disk_read_once = false;   /* true after first end-of-head */
+#define FDS_AUTO_EJECT_FRAMES    77
+#define FDS_AUTO_RETRY_FRAMES    200
+#define FDS_AUTO_MAX_ATTEMPTS    5
+#define FDS_4032_CHECK_WINDOW    (100 * 262)  /* ~100 frames of hsyncs */
+#define FDS_4032_CHECK_THRESHOLD 20
+#define FDS_END_OF_HEAD_COOLDOWN_FRAMES 77
 
 /* Mesen2-style expanded disk image. The raw .fds file contains only
    block payloads back to back; the BIOS expects a richer byte stream
@@ -297,6 +327,15 @@ static bool fdsBuildExpandedBuffer(BYTE *rawDisk, int sides)
 
     FDS_LOG("side %d: %d block(s), expanded size %lu B\n",
             s, blkIdx, (unsigned long)fds_side_sizes[s]);
+    /* Dump first few block positions and their leading bytes. */
+    for (int b = 0; b < blkIdx && b < 6; ++b)
+    {
+      DWORD pos = fds_block_starts[s][b];
+      BYTE val = fds_expanded[sideStart + pos];
+      FDS_LOG("  blk[%d] start=%lu end=%lu byte=0x%02X\n",
+              b, (unsigned long)pos,
+              (unsigned long)fds_block_ends[s][b], val);
+    }
   }
 
   fds_expanded_total_size = (DWORD)sides * perSideMax;
@@ -729,6 +768,119 @@ fail:
 }
 
 /*-------------------------------------------------------------------*/
+/*  fdsAutoInsertCheck: Mesen2 $E445 intercept.                      */
+/*  Called when the CPU PC reaches $E445 (BIOS disk-verify routine). */
+/*  Reads the 10-byte disk-header buffer that BIOS expects at the    */
+/*  address stored in zero-page $00-$01, matches it against all      */
+/*  disk-side headers, and auto-inserts the correct side.            */
+/*-------------------------------------------------------------------*/
+void fdsAutoInsertCheck()
+{
+  if (!FDS_AutoInsertEnabled || !fds_auto_insert_enabled || !IsFDS || !FDS_DiskImage) {
+    FDS_LOG("$E445: skip (enabled=%d IsFDS=%d img=%p)\n",
+            fds_auto_insert_enabled, IsFDS, FDS_DiskImage);
+    return;
+  }
+
+  /* Read buffer address from zero-page $00-$01. */
+  WORD bufferAddr = RAM[0x00] | ((WORD)RAM[0x01] << 8);
+  FDS_LOG("$E445: bufAddr=$%04X curSide=%d\n", bufferAddr, FDS_CurrentSide);
+
+  /* Read 10 bytes from that address (using direct memory access). */
+  BYTE buffer[10];
+  for (int i = 0; i < 10; i++)
+  {
+    WORD addr = bufferAddr + i;
+    /* Prevent infinite recursion: skip if the address is $E445 itself */
+    if (addr == 0xE445) { buffer[i] = 0xFF; continue; }
+    /* Read from the appropriate memory region */
+    if (addr < 0x2000)
+      buffer[i] = RAM[addr & 0x7FF];
+    else if (addr >= 0x6000 && addr < 0x8000)
+      buffer[i] = FDS_PrgRam ? FDS_PrgRam[addr - 0x6000] : 0;
+    else if (addr >= 0x8000 && addr < 0xE000)
+      buffer[i] = FDS_PrgRam ? FDS_PrgRam[(addr - 0x8000) + 0x2000] : 0;
+    else if (addr >= 0xE000)
+      buffer[i] = FDS_Bios ? FDS_Bios[addr & 0x1FFF] : 0;
+    else
+      buffer[i] = 0xFF; /* PPU/APU range — treat as wildcard */
+  }
+
+  /* Match against disk-side headers. Each side's header starts at
+     offset 0 in the raw .fds side data (block type 1 = disk info block,
+     56 bytes). The 10-byte comparison region starts at offset 14
+     (manufacturer code + game name). 0xFF in the buffer = wildcard. */
+  /* Dump buffer bytes for debugging. */
+  FDS_LOG("$E445: buf[10]=");
+  for (int i = 0; i < 10; i++) FDS_LOG(" %02X", buffer[i]);
+  FDS_LOG("\n");
+
+  int matchCount = 0;
+  int matchIndex = -1;
+  for (int s = 0; s < FDS_NumSides; s++)
+  {
+    /* Offset 15 = manufacturer code (skip block type 0x01 + 14-byte
+       "*NINTENDO-HVC*" string).  Mesen2 uses [i+14] but its header
+       array already strips the block-type byte. */
+    BYTE *sideHeader = FDS_DiskImage + (DWORD)s * FDS_SIDE_SIZE + 15;
+    FDS_LOG("$E445: hdr[%d]=", s);
+    for (int i = 0; i < 10; i++) FDS_LOG(" %02X", sideHeader[i]);
+    FDS_LOG("\n");
+    bool match = true;
+    for (int i = 0; i < 10; i++)
+    {
+      if (buffer[i] != 0xFF && buffer[i] != sideHeader[i])
+      {
+        match = false;
+        break;
+      }
+    }
+    if (match)
+    {
+      matchCount++;
+      matchIndex = (matchCount > 1) ? -1 : s;
+    }
+  }
+
+  FDS_LOG("$E445: matchCount=%d matchIndex=%d\n", matchCount, matchIndex);
+
+  if (matchCount > 1)
+  {
+    /* Multiple sides match — disable auto-insert to avoid loops. */
+    fds_auto_insert_enabled = false;
+    FDS_LOG("Auto-insert disabled: %d sides match header\n", matchCount);
+    return;
+  }
+
+  if (matchIndex >= 0 && matchIndex != FDS_CurrentSide)
+  {
+    /* Switch to the matched side. */
+    FDS_CurrentSide = matchIndex;
+    FDS_DiskInserted = true;
+    fdsResetTransferPosition();
+    fds_motor_spinup = 50;
+    fds_byte_irq_pend = 0;
+    fds_transfer_complete = 0;
+    /* Cancel retry timer — we found the right disk. */
+    fds_auto_retry_counter = -1;
+    fds_auto_eject_delay = -1;
+    fds_4032_read_count = 0;
+    FDS_LOG("Auto-inserted: Disk %d Side %c\n",
+            (matchIndex / 2) + 1, (matchIndex & 1) ? 'B' : 'A');
+  }
+  else if (matchIndex >= 0)
+  {
+    /* Same side already inserted — cancel retry, BIOS will proceed.
+       Reset disk_read_once so the $4032 polling detection won't
+       fire spuriously before the next full read cycle. */
+    fds_auto_retry_counter = -1;
+    fds_auto_eject_delay = -1;
+    fds_4032_read_count = 0;
+    fds_disk_read_once = false;
+  }
+}
+
+/*-------------------------------------------------------------------*/
 /*  fdsResetDrive: clear all drive state. Called from Map20_Init.    */
 /*-------------------------------------------------------------------*/
 void fdsResetDrive()
@@ -750,6 +902,7 @@ void fdsResetDrive()
   fds_byte_pos      = 0;
   fds_read_buf      = 0;
   fds_byte_irq_pend = 0;
+  fds_transfer_complete = 0;
   fds_end_of_head   = 0;
   fds_cycle_acc     = 0;
   fds_motor_spinup  = 0;
@@ -762,6 +915,18 @@ void fdsResetDrive()
   fds_eject_counter = 0;
   fds_pending_side  = -1;
   FDS_DiskInserted  = true;
+
+  /* Reset auto-disk-insert state. */
+  fds_auto_insert_enabled = true;
+  fds_4032_read_count     = 0;
+  fds_last_read_hsync     = 0;
+  fds_hsync_counter       = 0;
+  fds_auto_eject_delay    = -1;
+  fds_auto_retry_counter  = -1;
+  fds_auto_insert_attempts = 0;
+  fds_previous_side = 0;
+  fds_end_of_head_cooldown = 0;
+  fds_disk_read_once = false;
 
   fds_write_buf = 0;
   fds_block_count = 0;
@@ -816,12 +981,14 @@ void fdsApuWrite(WORD wAddr, BYTE byData)
          must NOT be cleared here (BIOS uses $4023 to ack/re-enable). */
       fds_timer_irq_pend = 0;
       fds_byte_irq_pend = 0;
+      fds_transfer_complete = 0;
     }
     break;
 
   case 0x4024: /* Disk write data */
     fds_write_buf = byData;
     fds_byte_irq_pend = 0;
+    fds_transfer_complete = 0;
     /* Mirror the $4031 read: reset the byte-pacing accumulator so the
        next byte production is a full FDS_CYC_PER_BYTE cycles away.
        Without this, the drive emits multiple write IRQs faster than
@@ -856,8 +1023,10 @@ void fdsApuWrite(WORD wAddr, BYTE byData)
     fds_byte_irq_en = (byData >> 7) & 0x01;
 
     /* Per Mesen2 (Fds.cpp $4025 handler): every $4025 write clears
-       the FDS-disk byte-ready IRQ source. */
+       the IRQ source, but NOT the transfer-complete flag.
+       The game may poll $4030 for bit 1 without using IRQs. */
     fds_byte_irq_pend = 0;
+    /* NOTE: do NOT clear fds_transfer_complete here. */
 
     /* Motor turning on: head returns to start of disk. */
     if (!prev_motor && fds_motor_on)
@@ -879,6 +1048,12 @@ void fdsApuWrite(WORD wAddr, BYTE byData)
     {
       fds_gap_ended = 0;
     }
+
+    /* NOTE: do NOT reset gap_ended on CRC control rising edge in read
+       mode.  Mesen2 doesn't do this — the BIOS itself clears gap_ended
+       by writing scan_start=0 ($4025 bit 6) between blocks.  Our fake
+       CRC bytes are non-zero, so resetting gap_ended here would cause
+       the CRC byte to immediately re-trigger gap_ended=1. */
 
     /* CRC control rising edge during a write: BIOS just signalled
        end-of-payload. For a synthesized block (one we created on the
@@ -924,15 +1099,14 @@ BYTE fdsApuRead(WORD wAddr)
   case 0x4030: /* Disk status */
   {
     BYTE r = 0;
-    if (fds_timer_irq_pend) r |= 0x01;
-    if (fds_byte_irq_pend)  r |= 0x02;
-    if (fds_end_of_head)    r |= 0x40;
-    /* Reading $4030 acknowledges both the timer IRQ flag (bit 0) and
-       the byte-ready flag (bit 1). Nestopia (Adapter::Peek_4030):
-       `unit.status = 0; ClearIRQ(); return status; ` — both flags
-       are cleared regardless of which one was set. */
-    fds_timer_irq_pend = 0;
-    fds_byte_irq_pend  = 0;
+    if (fds_timer_irq_pend)   r |= 0x01;
+    if (fds_transfer_complete) r |= 0x02;
+    if (fds_end_of_head)      r |= 0x40;
+    /* Reading $4030 acknowledges the timer IRQ (bit 0) and
+       the transfer-complete flag (bit 1), and clears the IRQ line. */
+    fds_timer_irq_pend    = 0;
+    fds_byte_irq_pend     = 0;
+    fds_transfer_complete = 0;
     if (r) FDS_LOG("  4030 -> %02X (pos=%lu ge=%d)\n", r,
                    (unsigned long)fds_byte_pos, (int)fds_gap_ended);
     return r;
@@ -941,7 +1115,8 @@ BYTE fdsApuRead(WORD wAddr)
   case 0x4031: /* Disk read data */
     FDS_BYTELOG("  4031 -> %02X (pos=%lu ge=%d pend=%d)\n",
                 fds_read_buf, (unsigned long)fds_byte_pos, (int)fds_gap_ended,
-                (int)fds_byte_irq_pend);
+                (int)fds_transfer_complete);
+    fds_transfer_complete = 0;
     fds_byte_irq_pend = 0;
     /* Reset the byte-pacing accumulator so the next byte production
        is a full FDS_CYC_PER_BYTE cycles away. Our HSync-quantised IRQ
@@ -960,6 +1135,40 @@ BYTE fdsApuRead(WORD wAddr)
     if (!FDS_DiskInserted)  r |= 0x05; /* not-inserted and not-ready */
     else if (!fds_motor_on || fds_motor_spinup > 0) r |= 0x02;
     /* Bit 2 (write protect) left clear: simulating a writable disk. */
+
+    /* Mesen2-style auto-disk-insert: track successive $4032 reads.
+       When the game polls this register many times in quick succession
+       it usually means it's waiting for a different disk side.
+       Only fires after end-of-head cooldown has expired (Mesen2:
+       _autoDiskEjectCounter == 0). */
+    if (FDS_AutoInsertEnabled && fds_auto_insert_enabled && FDS_DiskInserted &&
+        fds_auto_eject_delay < 0 && fds_eject_counter == 0 &&
+        fds_disk_read_once && fds_end_of_head_cooldown == 0)
+    {
+      int elapsed = fds_hsync_counter - fds_last_read_hsync;
+      if (elapsed < FDS_4032_CHECK_WINDOW)
+      {
+        fds_4032_read_count++;
+      }
+      else
+      {
+        fds_4032_read_count = 0;
+      }
+      fds_last_read_hsync = fds_hsync_counter;
+
+      if (fds_4032_read_count > FDS_4032_CHECK_THRESHOLD &&
+          fds_auto_insert_attempts < FDS_AUTO_MAX_ATTEMPTS)
+      {
+        /* Auto-eject: the game wants a different side. */
+        fds_previous_side = FDS_CurrentSide;
+        FDS_DiskInserted = false;
+        fds_auto_eject_delay = FDS_AUTO_EJECT_FRAMES * 262;
+        fds_4032_read_count = 0;
+        fds_auto_insert_attempts++;
+        r |= 0x05; /* reflect the ejection immediately */
+        FDS_LOG("Auto-eject triggered (attempt %d)\n", fds_auto_insert_attempts);
+      }
+    }
     return r;
   }
 
@@ -976,6 +1185,16 @@ BYTE fdsApuRead(WORD wAddr)
 /*-------------------------------------------------------------------*/
 void fdsHsync()
 {
+  /* Monotonic hsync counter for auto-insert timing. */
+  fds_hsync_counter++;
+
+  /* End-of-head cooldown: counts down once per frame (~262 hsyncs).
+     Mesen2 uses a per-frame counter; we approximate with hsyncs. */
+  if (fds_end_of_head_cooldown > 0 && (fds_hsync_counter % 262) == 0)
+  {
+    fds_end_of_head_cooldown--;
+  }
+
   /* Drive the disk-swap eject pulse before anything else: the BIOS
      reads $4032 in its disk-status loop and we want it to see the
      disk-not-inserted bit reliably while fds_eject_counter > 0. */
@@ -997,6 +1216,47 @@ void fdsHsync()
       fdsResetTransferPosition();
       fds_motor_spinup = 50;
       fds_byte_irq_pend = 0;
+      fds_transfer_complete = 0;
+    }
+  }
+
+  /* Auto-disk-insert countdown: after auto-eject, wait ~77 frames then
+     re-insert disk (side 0 as a placeholder — the $E445 intercept will
+     select the correct side when BIOS verifies the header). */
+  if (fds_auto_eject_delay > 0)
+  {
+    fds_auto_eject_delay--;
+    if (fds_auto_eject_delay == 0)
+    {
+      /* Cycle to the next side (Mesen2 behavior).  The $E445 hook
+         may still override this if the BIOS buffer requests a
+         specific different side. */
+      int nextSide = (fds_previous_side + 1) % FDS_NumSides;
+      FDS_CurrentSide = nextSide;
+      FDS_DiskInserted = true;
+      fdsResetTransferPosition();
+      fds_motor_spinup = 50;
+      fds_byte_irq_pend = 0;
+      fds_transfer_complete = 0;
+      fds_auto_retry_counter = FDS_AUTO_RETRY_FRAMES * 262;
+      FDS_LOG("Auto-insert: side %d (%c) inserted\n",
+              nextSide, (nextSide & 1) ? 'B' : 'A');
+    }
+  }
+
+  /* Auto-insert retry: if the game hasn't successfully read the disk
+     within ~200 frames of insertion, eject and try again. */
+  if (fds_auto_retry_counter > 0)
+  {
+    fds_auto_retry_counter--;
+    if (fds_auto_retry_counter == 0 &&
+        fds_auto_insert_attempts < FDS_AUTO_MAX_ATTEMPTS)
+    {
+      /* Eject and retry. */
+      FDS_DiskInserted = false;
+      fds_auto_eject_delay = (FDS_AUTO_EJECT_FRAMES / 2) * 262;
+      fds_auto_insert_attempts++;
+      FDS_LOG("Auto-insert retry (attempt %d)\n", fds_auto_insert_attempts);
     }
   }
 
@@ -1036,14 +1296,27 @@ void fdsHsync()
   if (fds_motor_spinup > 0)
   {
     fds_motor_spinup--;
+    /* Once spinup finishes, set scanning_started so rst=1 won't block.
+       Mesen2: _scanningDisk=true after delay expires. */
+    if (fds_motor_spinup == 0)
+      fds_scanning_started = 1;
   }
-  else if (fds_motor_on && fds_scan_start && FDS_DiskInserted &&
+  else if (fds_motor_on && FDS_DiskInserted &&
            fds_expanded && !fds_end_of_head)
   {
+    /* Mesen2: if(_resetTransfer && !_scanningDisk) return;
+       rst=1 prevents advancement only until the drive has started
+       scanning. Once scanning_started is true, rst=1 just resets
+       gap detection — the drive keeps advancing. */
+    if (fds_xfer_reset && !fds_scanning_started)
+    {
+      /* Drive blocked — waiting for spinup or rst release. */
+    }
+    else
+    {
     DWORD sideSize = fds_side_sizes[FDS_CurrentSide];
     BYTE *side     = fds_expanded + fds_side_offsets[FDS_CurrentSide];
     int   numBlocks = fds_block_counts[FDS_CurrentSide];
-    DWORD *bstarts  = fds_block_starts[FDS_CurrentSide];
     DWORD *bends    = fds_block_ends[FDS_CurrentSide];
 
     fds_cycle_acc += STEP_PER_SCANLINE;
@@ -1051,98 +1324,102 @@ void fdsHsync()
     {
       fds_cycle_acc -= FDS_CYC_PER_BYTE;
 
-      /* Linear walk. When gap_ended==0 the drive is hunting for the
-         next block start; bytes between here and that start (gap
-         zeros, leftover payload from rst-mid-block, fake CRC) are
-         consumed silently — no byte-ready IRQ. When pos reaches a
-         block start, gap_ended flips to 1 and emission begins on
-         this same tick (the first emitted byte is the block-type
-         byte at the block_start offset). From then on every byte
-         fires byte-ready until rst=1 resets gap_ended. */
-      if (!fds_gap_ended)
+      if (fds_byte_pos >= sideSize)
       {
-        DWORD nextStart = sideSize;
-        for (int i = 0; i < numBlocks; ++i)
-        {
-          if (bstarts[i] >= fds_byte_pos) { nextStart = bstarts[i]; break; }
-        }
-        /* Append support: in write mode, when we're past every existing
-           block, synthesize a new block one inter-block-gap past the
-           last block_end. The BIOS uses this to add a new file (e.g.
-           Metroid's first save) — without it the drive walks silently
-           toward end-of-head and BIOS errors out (ERR.24). If pos is
-           already past lastEnd+gap (BIOS spent some time positioning),
-           synth at the current pos so we don't keep walking forever. */
-        if (!fds_read_mode && nextStart == sideSize && numBlocks > 0 &&
-            numBlocks < FDS_MAX_BLOCKS_PER_SIDE)
-        {
-          DWORD lastEnd = bends[numBlocks - 1];
-          if (fds_byte_pos >= lastEnd)
-          {
-            DWORD synthPos = lastEnd + FDS_INTER_BLOCK_GAP;
-            if (synthPos < fds_byte_pos) synthPos = fds_byte_pos;
-            if (synthPos < sideSize)
-            {
-              nextStart = synthPos;
-            }
-          }
-        }
-        if (fds_byte_pos < nextStart)
-        {
-          fds_byte_pos++;
-          continue;
-        }
-        if (fds_byte_pos >= sideSize) { fds_end_of_head = 1; break; }
-        /* At a known (or synthesized) block start: arm for emission. */
-        fds_gap_ended = 1;
-        /* Register a synthesized block so future seeks find it.
-           Initial bends == bstarts is a placeholder that will be
-           overwritten when the BIOS asserts crc=1 (write mode end-of-
-           block trigger) or when 16 KB worst-case payload elapses. */
-        if (!fds_read_mode && numBlocks < FDS_MAX_BLOCKS_PER_SIDE)
-        {
-          bool isNew = true;
-          for (int i = 0; i < numBlocks; ++i)
-          {
-            if (bstarts[i] == fds_byte_pos) { isNew = false; break; }
-          }
-          if (isNew)
-          {
-            bstarts[numBlocks] = fds_byte_pos;
-            bends[numBlocks]   = fds_byte_pos;   /* placeholder */
-            fds_block_counts[FDS_CurrentSide]++;
-            numBlocks = fds_block_counts[FDS_CurrentSide];
-            FDS_LOG("synth block#%d at pos=%lu\n",
-                    numBlocks, (unsigned long)fds_byte_pos);
-          }
-        }
+        /* End of disk reached. Mesen2 behavior:
+           1. Turn off motor (BIOS will turn it back on to rewind)
+           2. Fire disk IRQ so BIOS's IRQ handler gets called
+           3. Start cooldown before auto-eject detection can fire */
+        fds_end_of_head = 1;
+        fds_motor_on = 0;
+        fds_end_of_head_cooldown = FDS_END_OF_HEAD_COOLDOWN_FRAMES;
+        fds_disk_read_once = true;
+        fds_transfer_complete = 1;
+        if (fds_byte_irq_en) fds_byte_irq_pend = 1;
+        FDS_LOG("END of head (side %d, pos=%lu)\n", FDS_CurrentSide,
+                (unsigned long)fds_byte_pos);
+        break;
       }
 
       fds_scanning_started = 1;
 
       if (fds_read_mode)
       {
-        fds_read_buf = side[fds_byte_pos];
+        /* READ MODE: gap detection applies.
+           Mesen2: when diskReady (scan_start) is false, force gap_ended=0.
+           When true and byte is non-zero while gap_ended==0, set gap_ended=1.
+           Mesen2 suppresses delivery on the gap-end byte because its
+           disk image always has a 0x80 mark byte before each block.
+           Our initial expanded buffer has NO mark bytes, but the BIOS
+           writes 0x80 marks when it writes blocks.  So: if the first
+           non-zero byte is 0x80, silently consume it (mark byte).
+           Otherwise deliver it normally (it IS the block type byte). */
+        BYTE diskByte = side[fds_byte_pos];
+
+        if (!fds_scan_start)
+        {
+          fds_gap_ended = 0;
+        }
+        else if (diskByte && !fds_gap_ended)
+        {
+          fds_gap_ended = 1;
+          FDS_LOG("GAP END: pos=%lu byte=0x%02X\n",
+                  (unsigned long)fds_byte_pos, diskByte);
+          if (diskByte == 0x80)
+          {
+            /* Mark byte written by BIOS — consume silently, don't
+               deliver to the game.  Next non-zero byte will be the
+               actual block type. */
+            fds_byte_pos++;
+            continue;
+          }
+        }
+
+        if (fds_gap_ended)
+        {
+          fds_transfer_complete = 1;
+          fds_read_buf = diskByte;
+          if (fds_byte_irq_en) fds_byte_irq_pend = 1;
+        }
+
+        fds_byte_pos++;
       }
       else
       {
-        side[fds_byte_pos] = fds_write_buf;
+        /* WRITE MODE: Mesen2 always transfers in write mode —
+           no gap detection. The BIOS manages positioning via scan_start.
+           When crc_control is set, the drive emits CRC bytes (we just
+           write zeros as placeholders). When !scan_start (diskReady=0),
+           the drive writes 0x00 (creating gap). */
+        BYTE writeData;
+        if (!fds_scan_start)
+        {
+          writeData = 0x00;  /* gap byte */
+        }
+        else if (fds_crc_control)
+        {
+          writeData = 0x00;  /* CRC placeholder */
+        }
+        else
+        {
+          writeData = fds_write_buf;
+          fds_transfer_complete = 1;
+          fds_byte_irq_pend = 1;
+        }
+        side[fds_byte_pos] = writeData;
         fdsMarkDirty(fds_side_offsets[FDS_CurrentSide] + fds_byte_pos);
+        fds_byte_pos++;
+        fds_gap_ended = 0;  /* Mesen2: _gapEnded=false after write */
       }
-      fds_byte_pos++;
-      fds_byte_irq_pend = 1;
 
-      /* If we just emitted the last CRC byte of a block, flip gap_ended
-         back to 0 so the inter-block gap zeros are walked silently —
-         BIOS would otherwise read those zeros as the next block's type
-         byte and reject the disk (ERR.23). */
-      for (int i = 0; i < numBlocks; ++i)
+      /* Cancel any pending auto-insert retry since disk is active. */
+      if (fds_auto_retry_counter > 0)
       {
-        if (bends[i] == fds_byte_pos) { fds_gap_ended = 0; break; }
+        fds_auto_retry_counter = -1;
+        fds_4032_read_count = 0;
       }
-
-      if (fds_byte_pos >= sideSize) { fds_end_of_head = 1; break; }
     }
+    } /* end else (rst check) */
   }
 
   /* Timer IRQ fires unconditionally on underflow (bit 0). The byte-

--- a/infones/InfoNES_FDS.h
+++ b/infones/InfoNES_FDS.h
@@ -74,4 +74,14 @@ bool fdsParse(BYTE *fdsImage, size_t fdsImageSize);
    is freed via the existing ROM_FILE_ADDR free path. */
 void fdsRelease();
 
+/* FDS expansion audio: reset state + render n samples into fds_wave_buffer.
+   fdsResetAudio() is called internally from fdsResetDrive(). */
+void fdsResetAudio();
+void fdsRenderAudio(unsigned int n);
+
+/* FDS audio enable flag and output buffer.  Allocated in Map20_Init,
+   freed in InfoNES_pAPUDone.  Buffer holds APU_MAX_SAMPLES_PER_SYNC bytes. */
+extern BYTE  ApuFdsEnable;
+extern BYTE *fds_wave_buffer;
+
 #endif /* INFONES_FDS_H */

--- a/infones/InfoNES_FDS.h
+++ b/infones/InfoNES_FDS.h
@@ -19,7 +19,9 @@ extern BYTE *FDS_DiskImage;     /* points into the PSRAM buffer that holds the d
 extern int   FDS_NumSides;
 extern int   FDS_CurrentSide;
 extern bool  FDS_DiskInserted;  /* set by phase 5 disk swap UI; defaults to true */
-extern bool  FDS_AutoInsertEnabled; /* user setting: auto disk side switching */
+/* FDS_AutoInsertEnabled reads directly from settings.flags.autoSwapFDS */
+#include "settings.h"
+#define FDS_AutoInsertEnabled (settings.flags.autoSwapFDS)
 
 /* Drive emulation hooks. Wired from Map20_Init. */
 void fdsResetDrive();

--- a/infones/InfoNES_FDS.h
+++ b/infones/InfoNES_FDS.h
@@ -19,12 +19,18 @@ extern BYTE *FDS_DiskImage;     /* points into the PSRAM buffer that holds the d
 extern int   FDS_NumSides;
 extern int   FDS_CurrentSide;
 extern bool  FDS_DiskInserted;  /* set by phase 5 disk swap UI; defaults to true */
+extern bool  FDS_AutoInsertEnabled; /* user setting: auto disk side switching */
 
 /* Drive emulation hooks. Wired from Map20_Init. */
 void fdsResetDrive();
 void fdsApuWrite(WORD wAddr, BYTE byData);
 BYTE fdsApuRead(WORD wAddr);
 void fdsHsync();
+
+/* Mesen2-style auto-disk-insert: called from K6502 step loop when
+   PC == $E445 (BIOS disk-verify routine). Matches the 10-byte header
+   buffer and auto-switches to the correct disk side. */
+void fdsAutoInsertCheck();
 
 /* Phase 5: disk swap UI hooks.
    - fdsRequestSwap(side): eject the current disk for ~1s of game time

--- a/infones/InfoNES_Mapper.cpp
+++ b/infones/InfoNES_Mapper.cpp
@@ -16,6 +16,7 @@
 #include "InfoNES_pAPU.h"
 #include "FrensHelpers.h"
 #include "K6502.h"
+#include "InfoNES_NSF.h"
 #include <pico.h>
 #if PICO_RP2350
 #include "InfoNES_FDS.h"
@@ -64,6 +65,7 @@ const struct MapperTable_tag MapperTable[] =
         {25, Map25_Init},
         {26, Map26_Init},
         {30, Map30_Init},
+        {31, MapNsf_Init},
         {32, Map32_Init},
         {33, Map33_Init},
         {34, Map34_Init},

--- a/infones/InfoNES_NSF.cpp
+++ b/infones/InfoNES_NSF.cpp
@@ -1,0 +1,591 @@
+/*===================================================================*/
+/*                                                                   */
+/*  InfoNES_NSF.cpp : Nintendo Sound Format (.nsf) playback          */
+/*                                                                   */
+/*  Reference: Mesen2 NsfMapper.cpp (SourMesen/Mesen2)              */
+/*                                                                   */
+/*===================================================================*/
+
+#include "InfoNES_NSF.h"
+#include "InfoNES.h"
+#include "InfoNES_System.h"
+#include "InfoNES_Mapper.h"
+#include "InfoNES_pAPU.h"
+#include "K6502.h"
+#include <cstring>
+#include <cstdio>
+
+/*-------------------------------------------------------------------*/
+/*  NSF global state                                                 */
+/*-------------------------------------------------------------------*/
+
+bool IsNSF = false;
+
+struct NsfHeader_tag NsfHeader;
+
+BYTE NsfCurrentTrack = 0;
+
+/* VU meter peak levels per channel */
+BYTE NsfVuLevels[5] = {};
+
+/* Playback state */
+bool NsfIsPlaying = false;
+int NsfFrameCounter = 0;
+static int NsfSilenceCounter = 0;
+
+/* Pointer to the raw NSF ROM data (after 128-byte header) */
+static const BYTE *NsfRomData = nullptr;
+static size_t NsfRomSize = 0;
+
+/* Current bank register values ($5FF8-$5FFF) */
+static BYTE NsfBankRegs[8];
+
+/* Whether this NSF uses bank switching */
+static bool NsfHasBanking = false;
+
+/* Number of 4KB pages in the NSF ROM data */
+static int NsfPageCount = 0;
+
+/* IRQ counter for PLAY routine timing (in CPU cycles) */
+static int NsfIrqCounter = 0;
+static int NsfIrqReloadValue = 0;
+
+/*-------------------------------------------------------------------*/
+/*  NSF BIOS (32 bytes, mapped at $4100-$411F)                       */
+/*                                                                   */
+/*  From Mesen2 NsfMapper.h:                                         */
+/*                                                                   */
+/*  .org $4100                                                       */
+/*  reset:                                                           */
+/*    CLI                    ; $4100: 58                              */
+/*    JSR [INIT]             ; $4101: 20 xx xx (patched)             */
+/*    STA $4100              ; $4104: 8D 00 41 (clear IRQ)           */
+/*    CLI                    ; $4107: 58                              */
+/*  loop:                                                            */
+/*    JMP loop               ; $4108: 4C 08 41                       */
+/*    (padding)              ; $410B-$410F: 00                       */
+/*                                                                   */
+/*  .org $4110                                                       */
+/*  irq:                                                             */
+/*    STA $4100              ; $4110: 8D 00 41 (clear IRQ)           */
+/*    JSR [PLAY]             ; $4113: 20 xx xx (patched)             */
+/*    CLI                    ; $4116: 58                              */
+/*    RTI                    ; $4117: 40                              */
+/*-------------------------------------------------------------------*/
+
+static BYTE NsfBios[0x20] = {
+    0x58, 0x20, 0x00, 0x00, 0x8D, 0x00, 0x41, 0x58,
+    0x4C, 0x08, 0x41, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x8D, 0x00, 0x41, 0x20, 0x00, 0x00, 0x58, 0x40,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+/*-------------------------------------------------------------------*/
+/*  Forward declarations for mapper callbacks                        */
+/*-------------------------------------------------------------------*/
+
+static void MapNsf_Write(WORD wAddr, BYTE byData);
+static void MapNsf_Sram(WORD wAddr, BYTE byData);
+static void MapNsf_Apu(WORD wAddr, BYTE byData);
+static BYTE MapNsf_ReadApu(WORD wAddr);
+static void MapNsf_VSync();
+static void MapNsf_HSync();
+static void MapNsf_PPU(WORD wAddr);
+static void MapNsf_RenderScreen(BYTE byMode);
+
+/*-------------------------------------------------------------------*/
+/*  Helper: apply a single 4KB bank register                         */
+/*                                                                   */
+/*  NSF uses 4KB pages, but ROMBANK[] is 8KB. We use ChrBuf as a    */
+/*  32KB shadow buffer and copy 4KB pages into it, then point        */
+/*  ROMBANK[] at the shadow.                                         */
+/*-------------------------------------------------------------------*/
+
+static void NsfApplyBanks()
+{
+    BYTE *shadow = ChrBuf;  /* Reuse ChrBuf (32KB, unused in NSF mode) */
+
+    /* Copy 8 × 4KB pages into shadow buffer */
+    for (int i = 0; i < 8; i++)
+    {
+        int page = NsfBankRegs[i];
+        const BYTE *src;
+        if (page < NsfPageCount)
+            src = NsfRomData + page * 0x1000;
+        else
+        {
+            /* Out of range — fill with zero (open bus equivalent) */
+            memset(shadow + i * 0x1000, 0, 0x1000);
+            continue;
+        }
+        memcpy(shadow + i * 0x1000, src, 0x1000);
+    }
+
+    /* Point ROMBANK[] at the shadow (4 × 8KB banks covering $8000-$FFFF) */
+    ROMBANK0 = shadow + 0x0000;  /* $8000-$9FFF */
+    ROMBANK1 = shadow + 0x2000;  /* $A000-$BFFF */
+    ROMBANK2 = shadow + 0x4000;  /* $C000-$DFFF */
+    ROMBANK3 = shadow + 0x6000;  /* $E000-$FFFF */
+
+    /* Patch CPU vectors into the top of the address space so that
+       K6502_Reset reads the correct reset and IRQ vectors. */
+    /* Reset vector ($FFFC-$FFFD) → $4100 (NSF BIOS reset) */
+    shadow[0x7FFC] = 0x00;
+    shadow[0x7FFD] = 0x41;
+    /* IRQ vector ($FFFE-$FFFF) → $4110 (NSF BIOS IRQ handler) */
+    shadow[0x7FFE] = 0x10;
+    shadow[0x7FFF] = 0x41;
+}
+
+/*===================================================================*/
+/*                                                                   */
+/*  nsfParse() : Parse an NSF file                                   */
+/*                                                                   */
+/*===================================================================*/
+
+bool nsfParse(const BYTE *data, size_t size)
+{
+    if (size < 128)
+    {
+        printf("[NSF] File too small (%zu bytes)\n", size);
+        return false;
+    }
+
+    /* Validate magic */
+    if (memcmp(data, "NESM\x1a", 5) != 0)
+    {
+        printf("[NSF] Invalid magic\n");
+        return false;
+    }
+
+    /* Parse header (128 bytes, little-endian) */
+    memcpy(&NsfHeader, data, sizeof(NsfHeader_tag));
+
+    /* Ensure strings are null-terminated */
+    NsfHeader.szSongName[31] = '\0';
+    NsfHeader.szArtistName[31] = '\0';
+    NsfHeader.szCopyright[31] = '\0';
+
+    printf("[NSF] Song: %s\n", NsfHeader.szSongName);
+    printf("[NSF] Artist: %s\n", NsfHeader.szArtistName);
+    printf("[NSF] Copyright: %s\n", NsfHeader.szCopyright);
+    printf("[NSF] Total songs: %d, starting: %d\n", NsfHeader.byTotalSongs, NsfHeader.byStartingSong);
+    printf("[NSF] Load: $%04X, Init: $%04X, Play: $%04X\n",
+           NsfHeader.wLoadAddress, NsfHeader.wInitAddress, NsfHeader.wPlayAddress);
+    printf("[NSF] Play speed NTSC: %d us, PAL: %d us\n",
+           NsfHeader.wPlaySpeedNtsc, NsfHeader.wPlaySpeedPal);
+    printf("[NSF] Sound chips: $%02X\n", NsfHeader.bySoundChips);
+
+    /* Adjust common timing values per Mesen2 */
+    if (NsfHeader.wPlaySpeedNtsc == 16666 || NsfHeader.wPlaySpeedNtsc == 16667)
+        NsfHeader.wPlaySpeedNtsc = 16639;
+    if (NsfHeader.wPlaySpeedPal == 20000)
+        NsfHeader.wPlaySpeedPal = 19997;
+
+    /* Store ROM data pointer (past 128-byte header) */
+    NsfRomData = data + 128;
+    NsfRomSize = size - 128;
+
+    /* Compute padding for load address alignment to 4KB boundary */
+    int loadOffset = NsfHeader.wLoadAddress % 0x1000;
+
+    /* Total ROM size with padding, rounded up to 4KB */
+    size_t paddedSize = loadOffset + NsfRomSize;
+    if (paddedSize % 0x1000 != 0)
+        paddedSize += 0x1000 - (paddedSize % 0x1000);
+
+    NsfPageCount = paddedSize / 0x1000;
+    printf("[NSF] Page count: %d (%zuKB padded)\n", NsfPageCount, paddedSize / 1024);
+
+    /* Check bank switching */
+    NsfHasBanking = false;
+    for (int i = 0; i < 8; i++)
+    {
+        if (NsfHeader.byBankSwitch[i] != 0)
+        {
+            NsfHasBanking = true;
+            break;
+        }
+    }
+
+    /* Set initial track */
+    NsfCurrentTrack = (NsfHeader.byStartingSong > 0) ? NsfHeader.byStartingSong - 1 : 0;
+
+    /* Patch INIT and PLAY addresses into the BIOS */
+    NsfBios[0x02] = NsfHeader.wInitAddress & 0xFF;
+    NsfBios[0x03] = (NsfHeader.wInitAddress >> 8) & 0xFF;
+    NsfBios[0x14] = NsfHeader.wPlayAddress & 0xFF;
+    NsfBios[0x15] = (NsfHeader.wPlayAddress >> 8) & 0xFF;
+
+    IsNSF = true;
+    return true;
+}
+
+/*===================================================================*/
+/*                                                                   */
+/*  nsfRelease() : Release NSF resources                             */
+/*                                                                   */
+/*===================================================================*/
+
+void nsfRelease()
+{
+    IsNSF = false;
+    NsfRomData = nullptr;
+    NsfRomSize = 0;
+    NsfPageCount = 0;
+    NsfHasBanking = false;
+}
+
+/*===================================================================*/
+/*                                                                   */
+/*  nsfSelectTrack() / nsfNextTrack() / nsfPrevTrack()               */
+/*                                                                   */
+/*===================================================================*/
+
+void nsfSelectTrack(BYTE track)
+{
+    if (track < NsfHeader.byTotalSongs)
+        NsfCurrentTrack = track;
+}
+
+void nsfNextTrack()
+{
+    if (NsfCurrentTrack + 1 < NsfHeader.byTotalSongs)
+        NsfCurrentTrack++;
+    else
+        NsfCurrentTrack = 0;
+}
+
+void nsfPrevTrack()
+{
+    if (NsfCurrentTrack > 0)
+        NsfCurrentTrack--;
+    else
+        NsfCurrentTrack = NsfHeader.byTotalSongs - 1;
+}
+
+/*===================================================================*/
+/*                                                                   */
+/*  nsfSetupCpuState() : Set CPU state for NSF playback              */
+/*                       Called after K6502_Reset()                   */
+/*                                                                   */
+/*===================================================================*/
+
+extern BYTE SP, A, X, Y, F;
+extern WORD PC;
+
+void nsfSetupCpuState()
+{
+    /* Set up bank switching */
+    if (NsfHasBanking)
+    {
+        memcpy(NsfBankRegs, NsfHeader.byBankSwitch, 8);
+    }
+    else
+    {
+        /* Auto-configure banks based on load address (per Mesen2) */
+        memset(NsfBankRegs, 0, 8);
+        int startBank = NsfHeader.wLoadAddress / 0x1000;
+        for (int i = 0; i < NsfPageCount; i++)
+        {
+            if (startBank + i - 8 >= 0 && startBank + i - 8 < 8)
+                NsfBankRegs[startBank + i - 8] = i;
+        }
+    }
+
+    NsfApplyBanks();
+
+    /* SRAMBANK points to SRAM (zero-filled by InfoNES_Reset) */
+    SRAMBANK = SRAM;
+
+    /* Set CPU registers per NSF spec */
+    A = NsfCurrentTrack;
+    X = (NsfHeader.byFlags & 0x01) ? 1 : 0;  /* 1=PAL, 0=NTSC */
+    Y = 0;
+    SP = 0xFD;
+    /* K6502_Reset() read PC from the reset vector before banks were
+       applied, so it has a stale value. Set PC explicitly to the
+       NSF BIOS entry point. */
+    PC = 0x4100;
+
+    /* Compute IRQ reload value: PlaySpeed_us × CPUClock / 1000000
+       NTSC CPU clock = 1789773 Hz */
+    WORD playSpeed = NsfHeader.wPlaySpeedNtsc;
+    if (playSpeed == 0)
+        playSpeed = 16639; /* Default ~60 Hz */
+    NsfIrqReloadValue = (int)(playSpeed * (1789773.0 / 1000000.0));
+    NsfIrqCounter = NsfIrqReloadValue;
+
+    /* Disable frame IRQ — NSF uses its own IRQ timer */
+    FrameIRQ_Enable = 0;
+
+    /* Enable expansion audio based on sound chip flags */
+    ApuMmc5Enable = (NsfHeader.bySoundChips & NSF_CHIP_MMC5) ? 1 : 0;
+    ApuVrc6Enable = (NsfHeader.bySoundChips & NSF_CHIP_VRC6) ? 1 : 0;
+    ApuSunsoft5BEnable = (NsfHeader.bySoundChips & NSF_CHIP_SUNSOFT) ? 1 : 0;
+
+    printf("[NSF] Playing track %d/%d, IRQ reload=%d cycles\n",
+           NsfCurrentTrack + 1, NsfHeader.byTotalSongs, NsfIrqReloadValue);
+
+    /* Start playback automatically */
+    nsfStartPlayback();
+}
+
+/*===================================================================*/
+/*                                                                   */
+/*  nsfUpdateVuLevels() : Compute VU peak levels from wave_buffers   */
+/*                                                                   */
+/*===================================================================*/
+
+extern BYTE (*wave_buffers)[APU_MAX_SAMPLES_PER_SYNC];
+
+void nsfUpdateVuLevels()
+{
+    if (!wave_buffers)
+        return;
+
+    /* Compute peak amplitude per channel for this frame.
+       wave_buffers values are 0-based (0 = silence):
+         ch 0,1 (Pulse):    0-15
+         ch 2   (Triangle): 0-255
+         ch 3   (Noise):    0-15
+         ch 4   (DPCM):     0-127  */
+
+    for (int ch = 0; ch < 5; ch++)
+    {
+        int peak = 0;
+        for (int i = 0; i < APU_MAX_SAMPLES_PER_SYNC; i += 4)
+        {
+            int val = wave_buffers[ch][i];
+            if (val > peak)
+                peak = val;
+        }
+
+        /* Scale to 0-255 based on channel max value */
+        int scaled;
+        switch (ch)
+        {
+        case 0: /* Pulse 1: max 15 */
+        case 1: /* Pulse 2: max 15 */
+        case 3: /* Noise:   max 15 */
+            scaled = peak * 255 / 15;
+            break;
+        case 2: /* Triangle: max 255 */
+            scaled = peak;
+            break;
+        case 4: /* DPCM: max ~127 */
+            scaled = peak * 2;
+            break;
+        default:
+            scaled = peak;
+            break;
+        }
+        if (scaled > 255)
+            scaled = 255;
+
+        /* Set level directly — no peak-hold, so bars track the music
+           in real time. Smooth with the previous level to avoid flicker. */
+        NsfVuLevels[ch] = (BYTE)((NsfVuLevels[ch] + scaled) / 2);
+    }
+}
+
+/*===================================================================*/
+/*                                                                   */
+/*  Playback control and auto-advance                                */
+/*                                                                   */
+/*===================================================================*/
+
+extern BYTE ApuCtrl;
+extern BYTE ApuCtrlNew;
+
+void nsfStartPlayback()
+{
+    NsfIsPlaying = true;
+    NsfFrameCounter = 0;
+    NsfSilenceCounter = 0;
+}
+
+void nsfStopPlayback()
+{
+    NsfIsPlaying = false;
+
+    /* Silence the APU: disable all channels and clear wave buffers */
+    ApuCtrl = 0;
+    ApuCtrlNew = 0;
+    if (wave_buffers)
+        memset(wave_buffers, 0, 5 * APU_MAX_SAMPLES_PER_SYNC);
+    memset(NsfVuLevels, 0, sizeof(NsfVuLevels));
+}
+
+bool nsfUpdatePlayback()
+{
+    if (!NsfIsPlaying)
+        return false;
+
+    NsfFrameCounter++;
+
+    /* Silence detection: check if all VU levels are zero */
+    bool silent = true;
+    for (int ch = 0; ch < 5; ch++)
+    {
+        if (NsfVuLevels[ch] > 2)
+        {
+            silent = false;
+            break;
+        }
+    }
+
+    if (silent)
+        NsfSilenceCounter++;
+    else
+        NsfSilenceCounter = 0;
+
+    /* Auto-advance: silence for too long, or max duration reached */
+    if (NsfSilenceCounter >= NSF_SILENCE_FRAMES ||
+        NsfFrameCounter >= NSF_MAX_TRACK_FRAMES)
+    {
+        nsfNextTrack();
+        NsfFrameCounter = 0;
+        NsfSilenceCounter = 0;
+        return true; /* Caller should set resetGame */
+    }
+
+    return false;
+}
+
+BYTE nsfGetProgress()
+{
+    if (NsfFrameCounter >= NSF_MAX_TRACK_FRAMES)
+        return 255;
+    return (BYTE)((NsfFrameCounter * 255) / NSF_MAX_TRACK_FRAMES);
+}
+
+/*===================================================================*/
+/*                                                                   */
+/*  MapNsf_Init() : Mapper 31 (NSF) initialization                  */
+/*                                                                   */
+/*===================================================================*/
+
+void MapNsf_Init()
+{
+    MapperInit = MapNsf_Init;
+    MapperWrite = MapNsf_Write;
+    MapperSram = MapNsf_Sram;
+    MapperApu = MapNsf_Apu;
+    MapperReadApu = MapNsf_ReadApu;
+    MapperVSync = MapNsf_VSync;
+    MapperHSync = MapNsf_HSync;
+    MapperPPU = MapNsf_PPU;
+    MapperRenderScreen = MapNsf_RenderScreen;
+
+    /* Set up initial banks and CPU vectors */
+    SRAMBANK = SRAM;
+    /* Banks will be fully configured by nsfSetupCpuState after K6502_Reset */
+}
+
+/*===================================================================*/
+/*                                                                   */
+/*  Mapper callback implementations                                  */
+/*                                                                   */
+/*===================================================================*/
+
+static void MapNsf_Write(WORD wAddr, BYTE byData)
+{
+    /* ROM area writes — ignored for NSF */
+    (void)wAddr;
+    (void)byData;
+}
+
+static void MapNsf_Sram(WORD wAddr, BYTE byData)
+{
+    /* SRAM writes handled by default K6502_Write */
+    (void)wAddr;
+    (void)byData;
+}
+
+static void MapNsf_Apu(WORD wAddr, BYTE byData)
+{
+    /* $4100: Clear IRQ (written by BIOS after JSR INIT/PLAY) */
+    if (wAddr == 0x4100)
+    {
+        IRQ_State = IRQ_Wiring; /* Clear pending IRQ */
+        return;
+    }
+
+    /* $5FF8-$5FFF: Bank switching registers */
+    if (wAddr >= 0x5FF8 && wAddr <= 0x5FFF)
+    {
+        int reg = wAddr - 0x5FF8;
+        NsfBankRegs[reg] = byData;
+        NsfApplyBanks();
+        return;
+    }
+
+    /* Expansion audio register dispatch */
+    if (NsfHeader.bySoundChips & NSF_CHIP_VRC6)
+    {
+        /* VRC6: $9000-$9003, $A000-$A002, $B000-$B002 */
+        if ((wAddr >= 0x9000 && wAddr <= 0x9003) ||
+            (wAddr >= 0xA000 && wAddr <= 0xA002) ||
+            (wAddr >= 0xB000 && wAddr <= 0xB002))
+        {
+            /* VRC6 audio writes are handled through the APU event queue
+               by the mapper APU callbacks. The existing pAPU VRC6
+               rendering picks them up from there. Queue them as APU events. */
+            /* Fall through to default — the existing mapper 24/26 APU
+               handler is not active, so we queue VRC6 events directly. */
+        }
+    }
+
+    if (NsfHeader.bySoundChips & NSF_CHIP_MMC5)
+    {
+        /* MMC5: $5000-$5015, $5205-$5206 */
+        if (wAddr >= 0x5000 && wAddr <= 0x5015)
+        {
+            /* MMC5 audio writes — queue through APU event system */
+        }
+    }
+}
+
+static BYTE MapNsf_ReadApu(WORD wAddr)
+{
+    /* $4100-$411F: NSF BIOS code */
+    if (wAddr >= 0x4100 && wAddr <= 0x411F)
+    {
+        return NsfBios[wAddr - 0x4100];
+    }
+
+    /* Default: open bus */
+    return (BYTE)(wAddr >> 8);
+}
+
+static void MapNsf_VSync()
+{
+    /* Nothing special — APU vsync handled by InfoNES_pAPUVsync */
+}
+
+static void MapNsf_HSync()
+{
+    /* When stopped, don't fire IRQs — PLAY routine won't be called */
+    if (!NsfIsPlaying)
+        return;
+
+    /* Decrement IRQ counter by CPU cycles per scanline.
+       When it reaches zero, fire IRQ and reload. */
+    NsfIrqCounter -= STEP_PER_SCANLINE;
+    if (NsfIrqCounter <= 0)
+    {
+        NsfIrqCounter += NsfIrqReloadValue;
+        IRQ_REQ;  /* Trigger IRQ → CPU jumps to $4110 → JSR PLAY */
+    }
+}
+
+static void MapNsf_PPU(WORD wAddr)
+{
+    (void)wAddr;
+}
+
+static void MapNsf_RenderScreen(BYTE byMode)
+{
+    (void)byMode;
+}

--- a/infones/InfoNES_NSF.cpp
+++ b/infones/InfoNES_NSF.cpp
@@ -12,8 +12,13 @@
 #include "InfoNES_Mapper.h"
 #include "InfoNES_pAPU.h"
 #include "K6502.h"
+#include "FrensHelpers.h"
 #include <cstring>
 #include <cstdio>
+
+#ifndef __not_in_flash_func
+#define __not_in_flash_func(name) name
+#endif
 
 /*-------------------------------------------------------------------*/
 /*  NSF global state                                                 */
@@ -49,6 +54,9 @@ static int NsfPageCount = 0;
 /* IRQ counter for PLAY routine timing (in CPU cycles) */
 static int NsfIrqCounter = 0;
 static int NsfIrqReloadValue = 0;
+
+/* Sunsoft 5B latched register index ($C000 selects, $E000 writes) */
+static BYTE NsfS5bReg = 0;
 
 /*-------------------------------------------------------------------*/
 /*  NSF BIOS (32 bytes, mapped at $4100-$411F)                       */
@@ -101,25 +109,30 @@ static void MapNsf_RenderScreen(BYTE byMode);
 /*  ROMBANK[] at the shadow.                                         */
 /*-------------------------------------------------------------------*/
 
-static void NsfApplyBanks()
+/* Apply a single 4KB bank register: copy only the page that changed.
+   Hot path: called from MapNsf_Apu on every $5FF8-$5FFF write. NSF play
+   routines (e.g. Castlevania/Akumajou1) re-program these registers many
+   times per frame, so this MUST be cheap. */
+static void __not_in_flash_func(NsfApplyBank)(int reg)
+{
+    BYTE *shadow = ChrBuf;
+    int page = NsfBankRegs[reg];
+    BYTE *dst = shadow + reg * 0x1000;
+    if (page < NsfPageCount)
+        memcpy(dst, NsfRomData + page * 0x1000, 0x1000);
+    else
+        memset(dst, 0, 0x1000);
+}
+
+/* Full bank shadow rebuild + ROMBANK pointer wiring + CPU vector patching.
+   Called once from nsfSetupCpuState(); subsequent bank-register writes
+   only update the page that changed via NsfApplyBank(). */
+static void NsfApplyAllBanks()
 {
     BYTE *shadow = ChrBuf;  /* Reuse ChrBuf (32KB, unused in NSF mode) */
 
-    /* Copy 8 × 4KB pages into shadow buffer */
     for (int i = 0; i < 8; i++)
-    {
-        int page = NsfBankRegs[i];
-        const BYTE *src;
-        if (page < NsfPageCount)
-            src = NsfRomData + page * 0x1000;
-        else
-        {
-            /* Out of range — fill with zero (open bus equivalent) */
-            memset(shadow + i * 0x1000, 0, 0x1000);
-            continue;
-        }
-        memcpy(shadow + i * 0x1000, src, 0x1000);
-    }
+        NsfApplyBank(i);
 
     /* Point ROMBANK[] at the shadow (4 × 8KB banks covering $8000-$FFFF) */
     ROMBANK0 = shadow + 0x0000;  /* $8000-$9FFF */
@@ -293,7 +306,7 @@ void nsfSetupCpuState()
         }
     }
 
-    NsfApplyBanks();
+    NsfApplyAllBanks();
 
     /* SRAMBANK points to SRAM (zero-filled by InfoNES_Reset) */
     SRAMBANK = SRAM;
@@ -319,10 +332,47 @@ void nsfSetupCpuState()
     /* Disable frame IRQ — NSF uses its own IRQ timer */
     FrameIRQ_Enable = 0;
 
-    /* Enable expansion audio based on sound chip flags */
+    /* Enable expansion audio based on sound chip flags, and allocate the
+       per-chip wave buffers that the pAPU mixer expects. Mappers 5/24/69
+       normally allocate these in their init paths, but those don't run
+       in NSF mode (we use synthetic mapper 31), so do it here. */
+#if PICO_RP2350
     ApuMmc5Enable = (NsfHeader.bySoundChips & NSF_CHIP_MMC5) ? 1 : 0;
+    if (ApuMmc5Enable && !mmc5_wave_buffers)
+    {
+        mmc5_wave_buffers = (BYTE (*)[APU_MAX_SAMPLES_PER_SYNC])
+            Frens::f_malloc(3 * APU_MAX_SAMPLES_PER_SYNC);
+        if (mmc5_wave_buffers)
+            memset((void *)mmc5_wave_buffers, 0, 3 * APU_MAX_SAMPLES_PER_SYNC);
+        else
+            ApuMmc5Enable = 0;
+    }
+#else
+    ApuMmc5Enable = 0;
+#endif
+
     ApuVrc6Enable = (NsfHeader.bySoundChips & NSF_CHIP_VRC6) ? 1 : 0;
+    if (ApuVrc6Enable && !vrc6_wave_buffers)
+    {
+        vrc6_wave_buffers = (BYTE (*)[APU_MAX_SAMPLES_PER_SYNC])
+            Frens::f_malloc(3 * APU_MAX_SAMPLES_PER_SYNC);
+        if (vrc6_wave_buffers)
+            memset((void *)vrc6_wave_buffers, 0, 3 * APU_MAX_SAMPLES_PER_SYNC);
+        else
+            ApuVrc6Enable = 0;
+    }
+
     ApuSunsoft5BEnable = (NsfHeader.bySoundChips & NSF_CHIP_SUNSOFT) ? 1 : 0;
+    if (ApuSunsoft5BEnable && !s5b_wave_buffers)
+    {
+        s5b_wave_buffers = (BYTE (*)[APU_MAX_SAMPLES_PER_SYNC])
+            Frens::f_malloc(3 * APU_MAX_SAMPLES_PER_SYNC);
+        if (s5b_wave_buffers)
+            memset((void *)s5b_wave_buffers, 0, 3 * APU_MAX_SAMPLES_PER_SYNC);
+        else
+            ApuSunsoft5BEnable = 0;
+    }
+    NsfS5bReg = 0;
 
     printf("[NSF] Playing track %d/%d, IRQ reload=%d cycles\n",
            NsfCurrentTrack + 1, NsfHeader.byTotalSongs, NsfIrqReloadValue);
@@ -489,11 +539,44 @@ void MapNsf_Init()
 /*                                                                   */
 /*===================================================================*/
 
-static void MapNsf_Write(WORD wAddr, BYTE byData)
+static void __not_in_flash_func(MapNsf_Write)(WORD wAddr, BYTE byData)
 {
-    /* ROM area writes — ignored for NSF */
-    (void)wAddr;
-    (void)byData;
+    /* ROM-area ($8000-$FFFF) writes: in NSF mode used only to drive
+       expansion audio chips that decode addresses in this range. */
+
+    /* VRC6 audio: decodes only A0, A1, A12-A15 → use (wAddr & 0xF003). */
+    if (NsfHeader.bySoundChips & NSF_CHIP_VRC6)
+    {
+        switch (wAddr & 0xF003)
+        {
+            case 0x9000: ApuWriteVrc6P1a(wAddr, byData); return;
+            case 0x9001: ApuWriteVrc6P1b(wAddr, byData); return;
+            case 0x9002: ApuWriteVrc6P1c(wAddr, byData); return;
+            case 0x9003: ApuWriteVrc6Freq(wAddr, byData); return;
+            case 0xA000: ApuWriteVrc6P2a(wAddr, byData); return;
+            case 0xA001: ApuWriteVrc6P2b(wAddr, byData); return;
+            case 0xA002: ApuWriteVrc6P2c(wAddr, byData); return;
+            case 0xB000: ApuWriteVrc6SawA(wAddr, byData); return;
+            case 0xB001: ApuWriteVrc6SawB(wAddr, byData); return;
+            case 0xB002: ApuWriteVrc6SawC(wAddr, byData); return;
+            default: break;
+        }
+    }
+
+    /* Sunsoft 5B: $C000 latches register index, $E000 writes data. */
+    if (NsfHeader.bySoundChips & NSF_CHIP_SUNSOFT)
+    {
+        switch (wAddr & 0xE000)
+        {
+            case 0xC000:
+                NsfS5bReg = byData & 0x0F;
+                return;
+            case 0xE000:
+                ApuWriteSunsoft5B(NsfS5bReg, byData);
+                return;
+            default: break;
+        }
+    }
 }
 
 static void MapNsf_Sram(WORD wAddr, BYTE byData)
@@ -503,7 +586,7 @@ static void MapNsf_Sram(WORD wAddr, BYTE byData)
     (void)byData;
 }
 
-static void MapNsf_Apu(WORD wAddr, BYTE byData)
+static void __not_in_flash_func(MapNsf_Apu)(WORD wAddr, BYTE byData)
 {
     /* $4100: Clear IRQ (written by BIOS after JSR INIT/PLAY) */
     if (wAddr == 0x4100)
@@ -512,39 +595,40 @@ static void MapNsf_Apu(WORD wAddr, BYTE byData)
         return;
     }
 
-    /* $5FF8-$5FFF: Bank switching registers */
+    /* $5FF8-$5FFF: Bank switching registers — incremental update only. */
     if (wAddr >= 0x5FF8 && wAddr <= 0x5FFF)
     {
         int reg = wAddr - 0x5FF8;
-        NsfBankRegs[reg] = byData;
-        NsfApplyBanks();
+        if (NsfBankRegs[reg] != byData)
+        {
+            NsfBankRegs[reg] = byData;
+            NsfApplyBank(reg);
+        }
         return;
     }
 
-    /* Expansion audio register dispatch */
-    if (NsfHeader.bySoundChips & NSF_CHIP_VRC6)
+#if PICO_RP2350
+    /* MMC5 expansion audio ($5000-$5015) — mirror Map5_Apu dispatch. */
+    if ((NsfHeader.bySoundChips & NSF_CHIP_MMC5) &&
+        wAddr >= 0x5000 && wAddr <= 0x5015)
     {
-        /* VRC6: $9000-$9003, $A000-$A002, $B000-$B002 */
-        if ((wAddr >= 0x9000 && wAddr <= 0x9003) ||
-            (wAddr >= 0xA000 && wAddr <= 0xA002) ||
-            (wAddr >= 0xB000 && wAddr <= 0xB002))
+        switch (wAddr)
         {
-            /* VRC6 audio writes are handled through the APU event queue
-               by the mapper APU callbacks. The existing pAPU VRC6
-               rendering picks them up from there. Queue them as APU events. */
-            /* Fall through to default — the existing mapper 24/26 APU
-               handler is not active, so we queue VRC6 events directly. */
+            case 0x5000: ApuWriteMmc5P1a(wAddr, byData); return;
+            case 0x5002: ApuWriteMmc5P1c(wAddr, byData); return;
+            case 0x5003: ApuWriteMmc5P1d(wAddr, byData); return;
+            case 0x5004: ApuWriteMmc5P2a(wAddr, byData); return;
+            case 0x5006: ApuWriteMmc5P2c(wAddr, byData); return;
+            case 0x5007: ApuWriteMmc5P2d(wAddr, byData); return;
+            case 0x5011:
+                if (byData != 0)
+                    ApuMmc5PcmValue = byData;
+                return;
+            case 0x5015: ApuWriteMmc5Ctrl(wAddr, byData); return;
+            default: return;
         }
     }
-
-    if (NsfHeader.bySoundChips & NSF_CHIP_MMC5)
-    {
-        /* MMC5: $5000-$5015, $5205-$5206 */
-        if (wAddr >= 0x5000 && wAddr <= 0x5015)
-        {
-            /* MMC5 audio writes — queue through APU event system */
-        }
-    }
+#endif
 }
 
 static BYTE MapNsf_ReadApu(WORD wAddr)
@@ -564,7 +648,7 @@ static void MapNsf_VSync()
     /* Nothing special — APU vsync handled by InfoNES_pAPUVsync */
 }
 
-static void MapNsf_HSync()
+static void __not_in_flash_func(MapNsf_HSync)()
 {
     /* When stopped, don't fire IRQs — PLAY routine won't be called */
     if (!NsfIsPlaying)

--- a/infones/InfoNES_NSF.cpp
+++ b/infones/InfoNES_NSF.cpp
@@ -404,11 +404,14 @@ void nsfUpdateVuLevels()
     for (int ch = 0; ch < 5; ch++)
     {
         int peak = 0;
+        int mn = 255, mx = 0;
         for (int i = 0; i < APU_MAX_SAMPLES_PER_SYNC; i += 4)
         {
             int val = wave_buffers[ch][i];
             if (val > peak)
                 peak = val;
+            if (val < mn) mn = val;
+            if (val > mx) mx = val;
         }
 
         /* Scale to 0-255 based on channel max value */
@@ -423,8 +426,11 @@ void nsfUpdateVuLevels()
         case 2: /* Triangle: max 255 */
             scaled = peak;
             break;
-        case 4: /* DPCM: max ~127 */
-            scaled = peak * 2;
+        case 4:
+            /* DPCM DAC holds its last value even when DMA is disabled, so a
+               stuck non-zero level would block silence-based auto-advance.
+               Measure AC range instead — DC offset reads as silence. */
+            scaled = (mx - mn) * 2;
             break;
         default:
             scaled = peak;
@@ -474,9 +480,12 @@ bool nsfUpdatePlayback()
 
     NsfFrameCounter++;
 
-    /* Silence detection: check if all VU levels are zero */
+    /* Silence detection: check the four melodic channels only.
+       DPCM is excluded because many NSFs leave a percussion sample
+       looping after the melody ends — it would never fall silent and
+       would block auto-advance indefinitely. */
     bool silent = true;
-    for (int ch = 0; ch < 5; ch++)
+    for (int ch = 0; ch < 4; ch++)
     {
         if (NsfVuLevels[ch] > 2)
         {

--- a/infones/InfoNES_NSF.cpp
+++ b/infones/InfoNES_NSF.cpp
@@ -321,6 +321,8 @@ void nsfPrevTrack()
 
 extern BYTE SP, A, X, Y, F;
 extern WORD PC;
+extern BYTE ApuCtrl;
+extern BYTE ApuCtrlNew;
 
 void nsfSetupCpuState()
 {
@@ -364,8 +366,23 @@ void nsfSetupCpuState()
     NsfIrqReloadValue = (int)(playSpeed * (1789773.0 / 1000000.0));
     NsfIrqCounter = NsfIrqReloadValue;
 
-    /* Disable frame IRQ — NSF uses its own IRQ timer */
+    /* NSF spec hardware-init sequence before INIT runs:
+         $4015 = $0F  enable pulse/triangle/noise (DMC stays off)
+         $4017 = $40  disable frame IRQ (4-step, IRQ inhibit)
+       Some NSFs (e.g. 1942Us) have INIT routines that don't touch $4015
+       themselves and rely on the player having pre-enabled the channels.
+       Without this, those tracks play silently after the APU is zeroed by
+       InfoNES_pAPUInit on each track-change reset.
+       Set ApuCtrl/ApuCtrlNew directly rather than going through the event
+       queue: at this point K6502_Reset has just zeroed the clock counter,
+       so an event queued here would carry a wrapped (large) timestamp from
+       the stale `entertime` left by pAPUInit and be silently dropped by
+       the first hsync. */
+    ApuCtrl = ApuCtrlNew = 0x0F;
+    APU_Reg[0x15] = 0x0F;
+    FrameStep = 0;
     FrameIRQ_Enable = 0;
+    APU_Reg[0x17] = 0x40;
 
     /* Enable expansion audio based on sound chip flags, and allocate the
        per-chip wave buffers that the pAPU mixer expects. Mappers 5/24/69
@@ -485,9 +502,6 @@ void nsfUpdateVuLevels()
 /*  Playback control and auto-advance                                */
 /*                                                                   */
 /*===================================================================*/
-
-extern BYTE ApuCtrl;
-extern BYTE ApuCtrlNew;
 
 void nsfStartPlayback()
 {

--- a/infones/InfoNES_NSF.cpp
+++ b/infones/InfoNES_NSF.cpp
@@ -51,6 +51,13 @@ static bool NsfHasBanking = false;
 /* Number of 4KB pages in the NSF ROM data */
 static int NsfPageCount = 0;
 
+/* Load-address offset within the first 4KB page. NSF data is conceptually
+   prefixed with this many zero bytes so that page 0 lands at LoadAddress
+   rounded down to a 4KB boundary, with the actual data starting at
+   (LoadAddress & 0xFFF). Required for NSFs whose LoadAddress isn't 4KB
+   aligned (e.g. 1942jp.nsf with LoadAddress=$9F80). */
+static int NsfLoadOffset = 0;
+
 /* IRQ counter for PLAY routine timing (in CPU cycles) */
 static int NsfIrqCounter = 0;
 static int NsfIrqReloadValue = 0;
@@ -118,10 +125,36 @@ static void __not_in_flash_func(NsfApplyBank)(int reg)
     BYTE *shadow = ChrBuf;
     int page = NsfBankRegs[reg];
     BYTE *dst = shadow + reg * 0x1000;
-    if (page < NsfPageCount)
-        memcpy(dst, NsfRomData + page * 0x1000, 0x1000);
-    else
+    if (page >= NsfPageCount)
+    {
         memset(dst, 0, 0x1000);
+        return;
+    }
+
+    /* Virtual page layout: NsfLoadOffset zero bytes prefix NsfRomData.
+       Map this page back to a [src, src+0x1000) window into NsfRomData,
+       zero-filling any portion outside [0, NsfRomSize). */
+    int src = page * 0x1000 - NsfLoadOffset;
+    int dstOff = 0;
+    int len = 0x1000;
+
+    if (src < 0)
+    {
+        int pad = -src;
+        if (pad > len) pad = len;
+        memset(dst, 0, pad);
+        dstOff += pad;
+        len -= pad;
+        src = 0;
+    }
+
+    int avail = (int)NsfRomSize - src;
+    if (avail < 0) avail = 0;
+    int copyLen = (len < avail) ? len : avail;
+    if (copyLen > 0)
+        memcpy(dst + dstOff, NsfRomData + src, copyLen);
+    if (copyLen < len)
+        memset(dst + dstOff + copyLen, 0, len - copyLen);
 }
 
 /* Full bank shadow rebuild + ROMBANK pointer wiring + CPU vector patching.
@@ -201,6 +234,7 @@ bool nsfParse(const BYTE *data, size_t size)
 
     /* Compute padding for load address alignment to 4KB boundary */
     int loadOffset = NsfHeader.wLoadAddress % 0x1000;
+    NsfLoadOffset = loadOffset;
 
     /* Total ROM size with padding, rounded up to 4KB */
     size_t paddedSize = loadOffset + NsfRomSize;
@@ -246,6 +280,7 @@ void nsfRelease()
     NsfRomData = nullptr;
     NsfRomSize = 0;
     NsfPageCount = 0;
+    NsfLoadOffset = 0;
     NsfHasBanking = false;
 }
 

--- a/infones/InfoNES_NSF.cpp
+++ b/infones/InfoNES_NSF.cpp
@@ -65,6 +65,52 @@ static int NsfIrqReloadValue = 0;
 /* Sunsoft 5B latched register index ($C000 selects, $E000 writes) */
 static BYTE NsfS5bReg = 0;
 
+/* 4KB-granular bank pointers used by K6502_Read in NSF mode. Switching
+   a bank is just a pointer write — for "clean" pages (fully covered by
+   NsfRomData with no zero padding) the pointer goes directly into the
+   flash-resident NSF data, eliminating the per-bank-write 4KB memcpy
+   that the original ChrBuf-shadow scheme paid (flash → PSRAM is slow,
+   ~10 MB/s, which dominated the per-frame budget on heavy bankswitchers
+   like Castlevania III). */
+BYTE *NsfBank4K[8] = { nullptr, nullptr, nullptr, nullptr,
+                       nullptr, nullptr, nullptr, nullptr };
+
+/* Shadow buffers for partial pages — built once per NSF load.
+     - NsfShadowZero: page index >= NsfPageCount (out of range).
+     - NsfShadowLead: physical page 0 when NsfLoadOffset > 0
+       (zero-padded prefix, then ROM bytes).
+     - NsfShadowTail: last physical page when NsfRomSize doesn't
+       end on a 4KB boundary (ROM bytes, then zero-padded suffix).
+   These are allocated in regular SRAM (plain malloc) rather than
+   PSRAM since they're hit by CPU-emulation reads. */
+static BYTE *NsfShadowZero = nullptr;
+static BYTE *NsfShadowLead = nullptr;
+static BYTE *NsfShadowTail = nullptr;
+static int NsfShadowLeadPage = -1;
+static int NsfShadowTailPage = -1;
+
+/* Build a 4KB shadow page that includes any required zero padding. */
+static void NsfBuildShadowPage(BYTE *dst, int page)
+{
+    int src = page * 0x1000 - NsfLoadOffset;
+    int dstOff = 0;
+    int len = 0x1000;
+    if (src < 0)
+    {
+        int pad = -src;
+        if (pad > len) pad = len;
+        memset(dst, 0, pad);
+        dstOff += pad;
+        len -= pad;
+        src = 0;
+    }
+    int avail = (int)NsfRomSize - src;
+    if (avail < 0) avail = 0;
+    int copyLen = (len < avail) ? len : avail;
+    if (copyLen > 0) memcpy(dst + dstOff, NsfRomData + src, copyLen);
+    if (copyLen < len) memset(dst + dstOff + copyLen, 0, len - copyLen);
+}
+
 /*-------------------------------------------------------------------*/
 /*  NSF BIOS (32 bytes, mapped at $4100-$411F)                       */
 /*                                                                   */
@@ -111,76 +157,91 @@ static void MapNsf_RenderScreen(BYTE byMode);
 /*-------------------------------------------------------------------*/
 /*  Helper: apply a single 4KB bank register                         */
 /*                                                                   */
-/*  NSF uses 4KB pages, but ROMBANK[] is 8KB. We use ChrBuf as a    */
-/*  32KB shadow buffer and copy 4KB pages into it, then point        */
-/*  ROMBANK[] at the shadow.                                         */
+/*  K6502_Read goes through NsfBank4K[] (4KB-granular) when IsNSF    */
+/*  is true. Switching a bank is just a pointer assignment — direct  */
+/*  into the flash-resident NSF data for clean pages, or into one of */
+/*  the prebuilt SRAM shadow pages for partial/out-of-range pages.   */
 /*-------------------------------------------------------------------*/
 
-/* Apply a single 4KB bank register: copy only the page that changed.
-   Hot path: called from MapNsf_Apu on every $5FF8-$5FFF write. NSF play
-   routines (e.g. Castlevania/Akumajou1) re-program these registers many
-   times per frame, so this MUST be cheap. */
 static void __not_in_flash_func(NsfApplyBank)(int reg)
 {
-    BYTE *shadow = ChrBuf;
     int page = NsfBankRegs[reg];
-    BYTE *dst = shadow + reg * 0x1000;
     if (page >= NsfPageCount)
     {
-        memset(dst, 0, 0x1000);
-        return;
+        NsfBank4K[reg] = NsfShadowZero;
     }
-
-    /* Virtual page layout: NsfLoadOffset zero bytes prefix NsfRomData.
-       Map this page back to a [src, src+0x1000) window into NsfRomData,
-       zero-filling any portion outside [0, NsfRomSize). */
-    int src = page * 0x1000 - NsfLoadOffset;
-    int dstOff = 0;
-    int len = 0x1000;
-
-    if (src < 0)
+    else if (page == NsfShadowLeadPage)
     {
-        int pad = -src;
-        if (pad > len) pad = len;
-        memset(dst, 0, pad);
-        dstOff += pad;
-        len -= pad;
-        src = 0;
+        NsfBank4K[reg] = NsfShadowLead;
     }
-
-    int avail = (int)NsfRomSize - src;
-    if (avail < 0) avail = 0;
-    int copyLen = (len < avail) ? len : avail;
-    if (copyLen > 0)
-        memcpy(dst + dstOff, NsfRomData + src, copyLen);
-    if (copyLen < len)
-        memset(dst + dstOff + copyLen, 0, len - copyLen);
+    else if (page == NsfShadowTailPage)
+    {
+        NsfBank4K[reg] = NsfShadowTail;
+    }
+    else
+    {
+        /* Clean page: fully covered by NsfRomData with no zero padding.
+           Read directly from flash, no copy. */
+        NsfBank4K[reg] = (BYTE *)(NsfRomData + page * 0x1000 - NsfLoadOffset);
+    }
 }
 
-/* Full bank shadow rebuild + ROMBANK pointer wiring + CPU vector patching.
-   Called once from nsfSetupCpuState(); subsequent bank-register writes
-   only update the page that changed via NsfApplyBank(). */
+/* Allocate (once) and rebuild the partial-page shadow buffers. Called
+   each time an NSF is loaded so a different LoadAddress / file size
+   from a previous NSF in the same boot doesn't carry over. */
+static void NsfBuildShadows()
+{
+    if (!NsfShadowZero) NsfShadowZero = (BYTE *)Frens::f_malloc(0x1000);
+    if (!NsfShadowLead) NsfShadowLead = (BYTE *)Frens::f_malloc(0x1000);
+    if (!NsfShadowTail) NsfShadowTail = (BYTE *)Frens::f_malloc(0x1000);
+    if (!NsfShadowZero || !NsfShadowLead || !NsfShadowTail)
+        return; /* malloc failure — out-of-range reads will crash, but
+                   we have no clean fallback so let the caller fail noisily. */
+
+    memset(NsfShadowZero, 0, 0x1000);
+
+    NsfShadowLeadPage = -1;
+    NsfShadowTailPage = -1;
+
+    /* Leading partial page: only when LoadAddress isn't 4KB-aligned. */
+    if (NsfLoadOffset > 0)
+    {
+        NsfShadowLeadPage = 0;
+        NsfBuildShadowPage(NsfShadowLead, 0);
+    }
+
+    /* Trailing partial page: when (LoadOffset + NsfRomSize) isn't a
+       multiple of 4KB, the last physical page has zero padding at the
+       end. Skip if it coincides with the leading page (tiny NSFs). */
+    int lastPage = NsfPageCount - 1;
+    if (lastPage > NsfShadowLeadPage)
+    {
+        int lastPageEnd = lastPage * 0x1000 - NsfLoadOffset + 0x1000;
+        if (lastPageEnd > (int)NsfRomSize)
+        {
+            NsfShadowTailPage = lastPage;
+            NsfBuildShadowPage(NsfShadowTail, lastPage);
+        }
+    }
+}
+
+/* Initial bank apply for all 8 registers. K6502 vectors at $FFFC-$FFFF
+   are no longer patched into a shadow buffer — they're served directly
+   by K6502_Read's NSF special case. */
 static void NsfApplyAllBanks()
 {
-    BYTE *shadow = ChrBuf;  /* Reuse ChrBuf (32KB, unused in NSF mode) */
-
+    NsfBuildShadows();
     for (int i = 0; i < 8; i++)
         NsfApplyBank(i);
 
-    /* Point ROMBANK[] at the shadow (4 × 8KB banks covering $8000-$FFFF) */
-    ROMBANK0 = shadow + 0x0000;  /* $8000-$9FFF */
-    ROMBANK1 = shadow + 0x2000;  /* $A000-$BFFF */
-    ROMBANK2 = shadow + 0x4000;  /* $C000-$DFFF */
-    ROMBANK3 = shadow + 0x6000;  /* $E000-$FFFF */
-
-    /* Patch CPU vectors into the top of the address space so that
-       K6502_Reset reads the correct reset and IRQ vectors. */
-    /* Reset vector ($FFFC-$FFFD) → $4100 (NSF BIOS reset) */
-    shadow[0x7FFC] = 0x00;
-    shadow[0x7FFD] = 0x41;
-    /* IRQ vector ($FFFE-$FFFF) → $4110 (NSF BIOS IRQ handler) */
-    shadow[0x7FFE] = 0x10;
-    shadow[0x7FFF] = 0x41;
+    /* ROMBANK[] is unused in NSF mode (K6502_Read goes via NsfBank4K),
+       but point it at ChrBuf anyway so any stray access from sprite-DMA
+       paths or leftover mapper code lands in addressable memory rather
+       than nullptr. */
+    ROMBANK0 = ChrBuf + 0x0000;
+    ROMBANK1 = ChrBuf + 0x2000;
+    ROMBANK2 = ChrBuf + 0x4000;
+    ROMBANK3 = ChrBuf + 0x6000;
 }
 
 /*===================================================================*/
@@ -282,6 +343,19 @@ void nsfRelease()
     NsfPageCount = 0;
     NsfLoadOffset = 0;
     NsfHasBanking = false;
+
+    /* Free the partial-page shadow buffers allocated by NsfBuildShadows
+       so we don't leak ~12KB of SRAM when the user exits NSF playback. */
+    if (NsfShadowZero) { Frens::f_free(NsfShadowZero); NsfShadowZero = nullptr; }
+    if (NsfShadowLead) { Frens::f_free(NsfShadowLead); NsfShadowLead = nullptr; }
+    if (NsfShadowTail) { Frens::f_free(NsfShadowTail); NsfShadowTail = nullptr; }
+    NsfShadowLeadPage = -1;
+    NsfShadowTailPage = -1;
+
+    /* Drop the bank pointers — NsfBank4K entries point into freed
+       buffers or into NsfRomData (which is becoming invalid). */
+    for (int i = 0; i < 8; i++)
+        NsfBank4K[i] = nullptr;
 }
 
 /*===================================================================*/

--- a/infones/InfoNES_NSF.h
+++ b/infones/InfoNES_NSF.h
@@ -1,0 +1,118 @@
+/*===================================================================*/
+/*                                                                   */
+/*  InfoNES_NSF.h : Nintendo Sound Format (.nsf) playback support    */
+/*                                                                   */
+/*===================================================================*/
+
+#ifndef InfoNES_NSF_H_INCLUDED
+#define InfoNES_NSF_H_INCLUDED
+
+#include "InfoNES_Types.h"
+#include <cstddef>
+
+/*-------------------------------------------------------------------*/
+/*  NSF Header (128 bytes)                                           */
+/*-------------------------------------------------------------------*/
+
+struct NsfHeader_tag
+{
+    BYTE byID[5];            /* "NESM\x1a" */
+    BYTE byVersion;          /* NSF version (usually 1) */
+    BYTE byTotalSongs;       /* Number of songs */
+    BYTE byStartingSong;     /* 1-indexed starting song */
+    WORD wLoadAddress;       /* Load address (>= $8000 or $6000 with banking) */
+    WORD wInitAddress;       /* INIT routine address */
+    WORD wPlayAddress;       /* PLAY routine address */
+    char szSongName[32];     /* Song name (null-terminated) */
+    char szArtistName[32];   /* Artist name */
+    char szCopyright[32];    /* Copyright holder */
+    WORD wPlaySpeedNtsc;     /* Play speed in microseconds (NTSC) */
+    BYTE byBankSwitch[8];    /* Bank switching init values ($5FF8-$5FFF) */
+    WORD wPlaySpeedPal;      /* Play speed in microseconds (PAL) */
+    BYTE byFlags;            /* bit 0: PAL/NTSC (0=NTSC, 1=PAL) */
+    BYTE bySoundChips;       /* Expansion audio chip flags */
+    BYTE byReserved[4];      /* Reserved (zero) */
+};
+
+/* Expansion sound chip flags (bySoundChips) */
+#define NSF_CHIP_VRC6    0x01
+#define NSF_CHIP_VRC7    0x02
+#define NSF_CHIP_FDS     0x04
+#define NSF_CHIP_MMC5    0x08
+#define NSF_CHIP_NAMCO   0x10
+#define NSF_CHIP_SUNSOFT 0x20
+
+/*-------------------------------------------------------------------*/
+/*  NSF global state                                                 */
+/*-------------------------------------------------------------------*/
+
+/* True when the loaded image is an NSF file */
+extern bool IsNSF;
+
+/* Parsed NSF header */
+extern struct NsfHeader_tag NsfHeader;
+
+/* Current track number (0-indexed) */
+extern BYTE NsfCurrentTrack;
+
+/*-------------------------------------------------------------------*/
+/*  NSF functions                                                    */
+/*-------------------------------------------------------------------*/
+
+/* Parse an NSF file from raw data. Returns true on success. */
+bool nsfParse(const BYTE *data, size_t size);
+
+/* Release NSF resources */
+void nsfRelease();
+
+/* Select a specific track (0-indexed). Triggers re-init on next reset. */
+void nsfSelectTrack(BYTE track);
+
+/* Advance to next track */
+void nsfNextTrack();
+
+/* Go to previous track */
+void nsfPrevTrack();
+
+/* Called after K6502_Reset() to set up CPU state for NSF playback */
+void nsfSetupCpuState();
+
+/* Peak VU level per channel (0-255), updated each frame */
+extern BYTE NsfVuLevels[5];
+
+/* Update VU levels from wave_buffers (call once per frame) */
+void nsfUpdateVuLevels();
+
+/* Playback state: true when track is actively playing */
+extern bool NsfIsPlaying;
+
+/* Frame counter for current track (incremented each frame while playing) */
+extern int NsfFrameCounter;
+
+/* Maximum track duration in frames (3 minutes at ~60fps) */
+#define NSF_MAX_TRACK_FRAMES (180 * 60)
+
+/* Number of consecutive silent frames before auto-advancing */
+#define NSF_SILENCE_FRAMES  (3 * 60)
+
+/* Start playing the current track */
+void nsfStartPlayback();
+
+/* Stop (pause) playback */
+void nsfStopPlayback();
+
+/* Call once per frame: updates counters, detects silence,
+   auto-advances to next track. Returns true if a track change
+   occurred (caller should set resetGame). */
+bool nsfUpdatePlayback();
+
+/* Get progress as 0-255 (elapsed / max duration) */
+BYTE nsfGetProgress();
+
+/*-------------------------------------------------------------------*/
+/*  NSF Mapper (mapper 31) functions                                 */
+/*-------------------------------------------------------------------*/
+
+void MapNsf_Init();
+
+#endif /* !InfoNES_NSF_H_INCLUDED */

--- a/infones/InfoNES_pAPU.cpp
+++ b/infones/InfoNES_pAPU.cpp
@@ -1981,7 +1981,13 @@ void __not_in_flash_func(InfoNES_pAPUHsync)(bool enabled)
   int bufferLeft = InfoNES_GetSoundBufferSize();
   n = std::min<int>(bufferLeft, n);
 
-  if (enabled)
+  /* In NSF mode, skip audio rendering when playback is stopped — otherwise
+     expansion-chip oscillators (VRC6 in particular) keep regenerating their
+     buffers from preserved phase state and the last tone bleeds through B's
+     stop until a new track starts. The else-branch zeros every output buffer
+     SoundOutput touches so stale samples can't leak via wave6 either. */
+  extern bool NsfIsPlaying;
+  if (enabled && (!IsNSF || NsfIsPlaying))
   {
     ApuRenderingWave1(n);
     ApuRenderingWave2(n);
@@ -2058,6 +2064,11 @@ void __not_in_flash_func(InfoNES_pAPUHsync)(bool enabled)
     memset(&wave_buffers[2][0], 0, n);
     memset(&wave_buffers[3][0], 0, n);
     memset(&wave_buffers[4][0], 0, n);
+    /* SoundOutput's wave6 reads s5b_wave_buffers[0] or fds_wave_buffer
+       depending on which expansion is enabled — zero those too so stopped
+       NSF (or muted APU) doesn't bleed expansion audio into the output. */
+    if (s5b_wave_buffers) memset(&s5b_wave_buffers[0][0], 0, n);
+    if (fds_wave_buffer)  memset(fds_wave_buffer, 0, n);
   }
 
   InfoNES_SoundOutput(n,

--- a/infones/InfoNES_pAPU.cpp
+++ b/infones/InfoNES_pAPU.cpp
@@ -14,6 +14,7 @@
 #include "InfoNES.h"
 #include "InfoNES_System.h"
 #include "InfoNES_pAPU.h"
+#include "InfoNES_FDS.h"
 #include "FrensHelpers.h"
 #include <algorithm>
 #include <string.h>
@@ -2024,6 +2025,16 @@ void __not_in_flash_func(InfoNES_pAPUHsync)(bool enabled)
       }
     }
 
+    /* Render and mix FDS expansion audio (wavetable + modulation).
+     * FDS audio is passed as the wave6 channel (shared with S5B, which
+     * is mutually exclusive since they're different mappers). This
+     * ensures FDS audio is mixed equally into L and R (mono) rather
+     * than being biased toward the pulse-1 stereo side. */
+    if (ApuFdsEnable)
+    {
+      fdsRenderAudio(n);
+    }
+
     /* Render Sunsoft 5B expansion audio (Mapper 69 — Gimmick!, Hebereke) into
      * its OWN output buffer.
      *
@@ -2057,7 +2068,8 @@ void __not_in_flash_func(InfoNES_pAPUHsync)(bool enabled)
   InfoNES_SoundOutput(n,
                       wave_buffers[0], wave_buffers[1], wave_buffers[2],
                       wave_buffers[3], wave_buffers[4],
-                      ApuSunsoft5BEnable ? s5b_wave_buffers[0] : nullptr);
+                      ApuSunsoft5BEnable ? s5b_wave_buffers[0] :
+                      (ApuFdsEnable ? fds_wave_buffer : nullptr));
 
 
   entertime = getPassedClocks();
@@ -2174,6 +2186,11 @@ void InfoNES_pAPUInit(void)
   ApuVrc6SawPhaseAcc = 0;
 
   /*-------------------------------------------------------------------*/
+  /*   Initialize FDS Audio                                            */
+  /*-------------------------------------------------------------------*/
+  ApuFdsEnable = 0;
+
+  /*-------------------------------------------------------------------*/
   /*   Initialize Sunsoft 5B Audio                                     */
   /*-------------------------------------------------------------------*/
   ApuSunsoft5BEnable = 0;
@@ -2217,6 +2234,7 @@ void InfoNES_pAPUDone(void)
   if (mmc5_wave_buffers) { Frens::f_free(mmc5_wave_buffers); mmc5_wave_buffers = nullptr; }
 #endif
   if (vrc6_wave_buffers) { Frens::f_free(vrc6_wave_buffers); vrc6_wave_buffers = nullptr; }
+  if (fds_wave_buffer) { Frens::f_free(fds_wave_buffer); fds_wave_buffer = nullptr; }
   if (s5b_wave_buffers) { Frens::f_free(s5b_wave_buffers); s5b_wave_buffers = nullptr; }
 }
 

--- a/infones/InfoNES_pAPU.cpp
+++ b/infones/InfoNES_pAPU.cpp
@@ -1375,38 +1375,34 @@ void __not_in_flash_func(ApuRenderingVrc6Pulse1)(int n)
 {
   ApuWriteVrc6Wave1(ApuCyclesPerSample * (n + 1), 0);
 
+  /* Halted by $9003 bit 0: leave channel silent for this sync. */
+  if (ApuVrc6FreqCtrl & 0x01)
+  {
+    memset(vrc6_wave_buffers[0], 0, n);
+    return;
+  }
+
+  /* Disabled by $9002 bit 7. */
+  if (!(ApuVrc6P1c & 0x80))
+  {
+    memset(vrc6_wave_buffers[0], 0, n);
+    return;
+  }
+
+  /* Hoist invariants — these only change when an event reprograms $9000. */
+  const BYTE vol  = ApuVrc6P1a & 0x0F;
+  const BYTE duty = (ApuVrc6P1a >> 4) & 0x07;
+  const BYTE mode = ApuVrc6P1a >> 7;
+  const BYTE volScaled = vol * 17;  /* scale 4-bit to 0..255 */
+
   for (unsigned int i = 0; i < n; i++)
   {
-    /* Halted by $9003 bit 0 */
-    if (ApuVrc6FreqCtrl & 0x01)
-    {
-      continue;
-    }
-
-    /* Disabled by $9002 bit 7 */
-    if (!(ApuVrc6P1c & 0x80))
-    {
-      vrc6_wave_buffers[0][i] = 0;
-      continue;
-    }
-
-    BYTE vol  = ApuVrc6P1a & 0x0F;
-    BYTE duty = (ApuVrc6P1a >> 4) & 0x07;
-    BYTE mode = ApuVrc6P1a >> 7;
-
     ApuVrc6P1Index += ApuVrc6P1Skip;
     ApuVrc6P1Index &= 0x1fffffff;
 
     BYTE step = ApuVrc6P1Index >> 25;  /* 0..15 */
 
-    if (mode || step >= (15 - duty))
-    {
-      vrc6_wave_buffers[0][i] = vol * 17;  /* scale 4-bit to 0..255 */
-    }
-    else
-    {
-      vrc6_wave_buffers[0][i] = 0;
-    }
+    vrc6_wave_buffers[0][i] = (mode || step >= (15 - duty)) ? volScaled : 0;
   }
 }
 
@@ -1468,36 +1464,31 @@ void __not_in_flash_func(ApuRenderingVrc6Pulse2)(int n)
 {
   ApuWriteVrc6Wave2(ApuCyclesPerSample * (n + 1), 0);
 
+  if (ApuVrc6FreqCtrl & 0x01)
+  {
+    memset(vrc6_wave_buffers[1], 0, n);
+    return;
+  }
+
+  if (!(ApuVrc6P2c & 0x80))
+  {
+    memset(vrc6_wave_buffers[1], 0, n);
+    return;
+  }
+
+  const BYTE vol  = ApuVrc6P2a & 0x0F;
+  const BYTE duty = (ApuVrc6P2a >> 4) & 0x07;
+  const BYTE mode = ApuVrc6P2a >> 7;
+  const BYTE volScaled = vol * 17;
+
   for (unsigned int i = 0; i < n; i++)
   {
-    if (ApuVrc6FreqCtrl & 0x01)
-    {
-      continue;
-    }
-
-    if (!(ApuVrc6P2c & 0x80))
-    {
-      vrc6_wave_buffers[1][i] = 0;
-      continue;
-    }
-
-    BYTE vol  = ApuVrc6P2a & 0x0F;
-    BYTE duty = (ApuVrc6P2a >> 4) & 0x07;
-    BYTE mode = ApuVrc6P2a >> 7;
-
     ApuVrc6P2Index += ApuVrc6P2Skip;
     ApuVrc6P2Index &= 0x1fffffff;
 
     BYTE step = ApuVrc6P2Index >> 25;
 
-    if (mode || step >= (15 - duty))
-    {
-      vrc6_wave_buffers[1][i] = vol * 17;
-    }
-    else
-    {
-      vrc6_wave_buffers[1][i] = 0;
-    }
+    vrc6_wave_buffers[1][i] = (mode || step >= (15 - duty)) ? volScaled : 0;
   }
 }
 
@@ -1544,30 +1535,34 @@ void __not_in_flash_func(ApuRenderingVrc6Saw)(int n)
 {
   ApuWriteVrc6SawWave(ApuCyclesPerSample * (n + 1), 0);
 
+  /* Halted: hold the current accumulator value across the sync. */
+  if (ApuVrc6FreqCtrl & 0x01)
+  {
+    BYTE held = (ApuVrc6SawAccum >> 3) * 8;
+    memset(vrc6_wave_buffers[2], held, n);
+    return;
+  }
+
+  /* Disabled: silence. */
+  if (!(ApuVrc6SawFreqH & 0x80))
+  {
+    memset(vrc6_wave_buffers[2], 0, n);
+    return;
+  }
+
+  /* Hoist the divider period — only changes on writes to $B001/$B002 or
+     $9003 (freq-ctrl), all of which are processed by ApuWriteVrc6SawWave
+     before the per-sample loop runs. */
+  DWORD freq_reg = (((DWORD)(ApuVrc6SawFreqH & 0x0F) << 8) | ApuVrc6SawFreqL);
+  if (ApuVrc6FreqCtrl & 0x04) freq_reg >>= 8;
+  else if (ApuVrc6FreqCtrl & 0x02) freq_reg >>= 4;
+  const int period = (int)freq_reg + 1;
+  const int decrement = (int)ApuCyclesPerSample;
+
   for (unsigned int i = 0; i < n; i++)
   {
-    /* Halted */
-    if (ApuVrc6FreqCtrl & 0x01)
-    {
-      vrc6_wave_buffers[2][i] = (ApuVrc6SawAccum >> 3) * 8;
-      continue;
-    }
-
-    /* Disabled */
-    if (!(ApuVrc6SawFreqH & 0x80))
-    {
-      vrc6_wave_buffers[2][i] = 0;
-      continue;
-    }
-
-    /* Compute effective divider period */
-    DWORD freq_reg = (((DWORD)(ApuVrc6SawFreqH & 0x0F) << 8) | ApuVrc6SawFreqL);
-    if (ApuVrc6FreqCtrl & 0x04) freq_reg >>= 8;
-    else if (ApuVrc6FreqCtrl & 0x02) freq_reg >>= 4;
-    int period = (int)freq_reg + 1;
-
     /* Advance divider - one divider tick per (period) CPU cycles */
-    ApuVrc6SawPhaseAcc -= (int)ApuCyclesPerSample;
+    ApuVrc6SawPhaseAcc -= decrement;
     while (ApuVrc6SawPhaseAcc < 0)
     {
       ApuVrc6SawPhaseAcc += period;

--- a/infones/InfoNES_pAPU.h
+++ b/infones/InfoNES_pAPU.h
@@ -304,6 +304,12 @@ extern BYTE ApuSunsoft5BEnable;
 extern BYTE (*s5b_wave_buffers)[APU_MAX_SAMPLES_PER_SYNC];
 
 /*-------------------------------------------------------------------*/
+/*  FDS Audio State (defined in InfoNES_FDS.cpp)                     */
+/*-------------------------------------------------------------------*/
+extern BYTE  ApuFdsEnable;
+extern BYTE *fds_wave_buffer;
+
+/*-------------------------------------------------------------------*/
 /*  Sunsoft 5B Audio Write Function                                  */
 /*    reg: 4-bit register index (0-15) previously latched via $C000 */
 /*    value: byte previously written to $E000                        */

--- a/infones/K6502.cpp
+++ b/infones/K6502.cpp
@@ -12,6 +12,8 @@
 
 #include "K6502.h"
 #include "InfoNES_System.h"
+#include "InfoNES.h"
+#include "InfoNES_FDS.h"
 
 #include <stdio.h>
 #include <pico.h>
@@ -495,6 +497,13 @@ static void __not_in_flash_func(step)(int wClocks)
     // {
     //   printf("A:%02X X:%02X Y:%02X SP:%02X F:%02X  %04X\n", A, X, Y, SP, F, PC);
     // }
+
+    /* Mesen2-style FDS auto-disk-insert: intercept BIOS $E445 (disk
+       verification routine) to auto-switch to the correct side. */
+    if (IsFDS && PC == 0xE445)
+    {
+      fdsAutoInsertCheck();
+    }
 
     // Read an instruction
     byCode = K6502_Read(PC++);

--- a/infones/K6502_rw.h
+++ b/infones/K6502_rw.h
@@ -20,6 +20,11 @@
 #include <pico.h>
 #include <stdio.h>
 
+/* NSF mode reads $8000-$FFFF via this 4KB-granular pointer table
+   (defined in InfoNES_NSF.cpp). Direct flash pointers for clean pages,
+   prebuilt shadow buffers for partial/out-of-range pages. */
+extern BYTE *NsfBank4K[8];
+
 /*===================================================================*/
 /*                                                                   */
 /*            K6502_ReadZp() : Reading from the zero page            */
@@ -70,6 +75,23 @@ static inline BYTE __not_in_flash_func(K6502_Read)(WORD wAddr)
 
   if (wAddr >= 0x8000)
   {
+    if (IsNSF)
+    {
+      /* NSF reset/IRQ vectors are hardcoded so NsfBank4K can point
+         directly into flash without a shadow buffer holding patched
+         vectors at $7FFC-$7FFF. */
+      if (wAddr >= 0xFFFC)
+      {
+        switch (wAddr)
+        {
+          case 0xFFFC: return 0x00;
+          case 0xFFFD: return 0x41;  /* reset → $4100 */
+          case 0xFFFE: return 0x10;
+          case 0xFFFF: return 0x41;  /* IRQ   → $4110 */
+        }
+      }
+      return NsfBank4K[(wAddr - 0x8000) >> 12][wAddr & 0xFFF];
+    }
     return ROMBANK[(wAddr - 0x8000) >> 13][wAddr & 0x1fff];
   }
 

--- a/infones/mapper/InfoNES_Mapper_020.cpp
+++ b/infones/mapper/InfoNES_Mapper_020.cpp
@@ -74,6 +74,13 @@ void Map20_Init()
 
   /* Initialise disk drive state (timer regs, transfer position, ...). */
   fdsResetDrive();
+
+  /* Allocate FDS expansion audio output buffer and enable rendering. */
+  if (!fds_wave_buffer)
+    fds_wave_buffer = (BYTE *)Frens::f_malloc(APU_MAX_SAMPLES_PER_SYNC);
+  if (fds_wave_buffer)
+    InfoNES_MemorySet(fds_wave_buffer, 0, APU_MAX_SAMPLES_PER_SYNC);
+  ApuFdsEnable = 1;
 }
 
 /*-------------------------------------------------------------------*/

--- a/main.cpp
+++ b/main.cpp
@@ -207,13 +207,8 @@ void saveNVRAM()
 #if PICO_RP2350
     if (IsFDS)
     {
-        /* Sidecar persistence is disabled until the Mesen2-style
-           expanded-image refactor lands — without it, our writes
-           corrupt the raw .fds layout, so we must not save those
-           bytes back to /SAVES or they'll wreck the next session.
-           Keep the function body so the dispatch wiring stays
-           intact for when the refactor lands. */
-        (void)pad;
+        snprintf(pad, FF_MAX_LFN, "%s/%s_fds.SAV", GAMESAVEDIR, fileName);
+        fdsSaveSidecar(pad);
         return;
     }
 #endif
@@ -257,11 +252,8 @@ bool loadNVRAM()
 #if PICO_RP2350
     if (IsFDS)
     {
-        /* Sidecar load disabled — see saveNVRAM for rationale. With a
-           pristine disk image, FDS games run their stock state on every
-           launch (no save persistence yet, but no corruption either). */
-        (void)pad;
-        return true;
+        snprintf(pad, FF_MAX_LFN, "%s/%s_fds.SAV", GAMESAVEDIR, fileName);
+        return fdsLoadSidecar(pad);
     }
 #endif
 

--- a/main.cpp
+++ b/main.cpp
@@ -99,6 +99,7 @@ int8_t g_settings_visibility_nes[MOPT_COUNT] = {
     1,                               // Rapid Fire on A
     1,                               // Rapid Fire on B
     1,                               // Enter bootsel mode
+    1,                               // Auto Swap FDS
     0                                // FDS Disk Swap (toggled on after fdsParse succeeds)
 };
 // #if defined(__riscv)

--- a/main.cpp
+++ b/main.cpp
@@ -25,6 +25,7 @@
 #include "soundrecorder.h"
 #include "pico/bootrom.h"
 #include "InfoNES_FDS.h"
+#include "InfoNES_NSF.h"
 #if EMBEDDED_NES_ROM
 extern "C" const unsigned char embedded_nes_rom[];
 extern "C" const unsigned int embedded_nes_rom_len;
@@ -460,7 +461,7 @@ void InfoNES_PadState(DWORD *pdwPad1, DWORD *pdwPad2, DWORD *pdwSystem)
         //         quickSaveAction = SaveStateTypes::SAVE;
         //     }
         // }
-        if (p1 & SELECT)
+        if (p1 & SELECT && !IsNSF)
         {
             if (pushed & START)
             {
@@ -526,7 +527,51 @@ void InfoNES_PadState(DWORD *pdwPad1, DWORD *pdwPad2, DWORD *pdwSystem)
 
         prevButtons[i] = v;
     }
-    if (reset)
+
+    /* NSF track controls (player 1 only, checked after button state update) */
+    if (IsNSF)
+    {
+        static constexpr int LEFT = 1 << 6;
+        static constexpr int RIGHT = 1 << 7;
+        static constexpr int START = 1 << 3;
+        static constexpr int SELECT = 1 << 2;
+        static constexpr int A_BTN = 1 << 0;
+        static constexpr int B_BTN = 1 << 1;
+
+        /* Recalculate pushed for player 1: edges since last frame. */
+        static DWORD nsfPrevPad = 0;
+        DWORD nsfPushed = prevButtons[0] & ~nsfPrevPad;
+        nsfPrevPad = prevButtons[0];
+
+        if (!(prevButtons[0] & START) && !(prevButtons[0] & SELECT))
+        {
+            if (nsfPushed & RIGHT)
+            {
+                nsfNextTrack();
+                /* Trigger a re-init by resetting the CPU state */
+                resetGame = true;
+            }
+            else if (nsfPushed & LEFT)
+            {
+                nsfPrevTrack();
+                resetGame = true;
+            }
+        }
+
+        /* A = play, B = stop */
+        if (nsfPushed & A_BTN)
+            nsfStartPlayback();
+        if (nsfPushed & B_BTN)
+            nsfStopPlayback();
+
+        if ((prevButtons[0] & SELECT) && (nsfPushed & START))
+        {
+            /* Select+Start: exit NSF playback, return to menu */
+            reset = true;
+        }
+    }
+
+    if (reset && !IsNSF)
     {
         saveNVRAM();
     }
@@ -583,6 +628,34 @@ bool parseROM(const uint8_t *nesFile)
         return true;
     }
 #endif
+
+    // NSF (Nintendo Sound Format) detection — check magic or file extension.
+    if (checkNSFMagic(nesFile))
+    {
+        // If already in NSF mode (e.g. track change via resetGame), skip re-parse
+        // so that NsfCurrentTrack is preserved.
+        if (IsNSF)
+            return true;
+
+        // Determine file size via f_stat (works for both SD and flash-based files).
+        size_t fileSize = 0;
+        FILINFO fno;
+        if (f_stat(romName, &fno) == FR_OK)
+            fileSize = (size_t)fno.fsize;
+        if (fileSize == 0)
+        {
+            snprintf(ErrorMessage, ERRORMESSAGESIZE, "Cannot determine NSF file size");
+            return false;
+        }
+        if (!nsfParse(nesFile, fileSize))
+        {
+            snprintf(ErrorMessage, ERRORMESSAGESIZE, "NSF parse error");
+            return false;
+        }
+        ROM = nullptr;
+        VROM = nullptr;
+        return true;
+    }
 
     memcpy(&NesHeader, nesFile, sizeof(NesHeader));
     if (!checkNESMagic(NesHeader.byID))
@@ -644,6 +717,14 @@ void InfoNES_ReleaseRom()
 {
     ROM = nullptr;
     VROM = nullptr;
+    if (IsNSF)
+    {
+        /* On a track-change reset (resetGame), keep NSF state alive so
+           the current track number is preserved across the re-init. */
+        if (!resetGame)
+            nsfRelease();
+        return;
+    }
 #if PICO_RP2350
     if (IsFDS)
     {
@@ -973,6 +1054,15 @@ int InfoNES_LoadFrame()
     //Frens::waitForVSync();
     Frens::pollHeadPhoneJack();
     EXT_AUDIO_POLL_HEADPHONE();
+
+    /* NSF: update VU meter levels once per frame */
+    if (IsNSF)
+    {
+        nsfUpdateVuLevels();
+        /* Check for auto-advance (silence detection / max duration) */
+        if (nsfUpdatePlayback())
+            resetGame = true;
+    }
 #if NES_PIN_CLK != -1
     nespad_read_start();
 #endif
@@ -1015,7 +1105,7 @@ int InfoNES_LoadFrame()
     }
 #endif
    
-    if (showSettings)
+    if (showSettings && !IsNSF)
     {
         showSettings = false;
         int rval = showSettingsMenu(true);
@@ -1036,7 +1126,7 @@ int InfoNES_LoadFrame()
            resetGame = true;
         }
     }
-    if (loadSaveStateMenu) {
+    if (loadSaveStateMenu && !IsNSF) {
         if (quickSaveAction == SaveStateTypes::LOAD_AND_START) {
             if (framesbeforeAutoStateIsLoaded > 0) {
                 --framesbeforeAutoStateIsLoaded;  // let the emulator run for a few frames before loading state
@@ -1103,6 +1193,137 @@ void __not_in_flash_func(drawWorkMeter)(int line)
     //    util::WorkMeterEnum(160, clocksPerLine * 2, drawWorkMeterUnit);
 }
 #endif
+
+/*-------------------------------------------------------------------*/
+/*  NSF display helper: draw a text string on a scanline             */
+/*-------------------------------------------------------------------*/
+static void nsfDrawText(WORD *buf, int x, int line, const char *text, int textRow, WORD fgc, WORD bgc)
+{
+    for (int i = 0; text[i] != '\0'; i++)
+    {
+        char fontSlice = getcharslicefrom8x8font(text[i], textRow);
+        for (int bit = 0; bit < 8; bit++)
+        {
+            buf[x + i * 8 + bit] = (fontSlice & 1) ? fgc : bgc;
+            fontSlice >>= 1;
+        }
+    }
+}
+
+/*-------------------------------------------------------------------*/
+/*  NSF display: render VU meter UI on a scanline                    */
+/*                                                                   */
+/*  Layout (320 pixels wide, lines 4-235):                           */
+/*   Lines  20-27:  Song name                                        */
+/*   Lines  36-43:  Artist name                                      */
+/*   Lines  52-59:  Copyright                                        */
+/*   Lines  72-79:  Track N / Total                                  */
+/*   Lines  96-103: "Pulse 1" bar label                              */
+/*   Lines 104-111: Pulse 1 VU bar                                   */
+/*   Lines 116-123: "Pulse 2" bar label                              */
+/*   Lines 124-131: Pulse 2 VU bar                                   */
+/*   Lines 136-143: "Triangle" bar label                             */
+/*   Lines 144-151: Triangle VU bar                                  */
+/*   Lines 156-163: "Noise" bar label                                */
+/*   Lines 164-171: Noise VU bar                                     */
+/*   Lines 176-183: "DPCM" bar label                                 */
+/*   Lines 184-191: DPCM VU bar                                      */
+/*-------------------------------------------------------------------*/
+static void nsfRenderLine(WORD *buf, int line)
+{
+    /* NES palette indices for colors */
+    WORD bgc = NesPalette[0x0F];   /* Black */
+    WORD fgc = NesPalette[0x30];   /* White */
+
+    /* Fill background */
+    for (int i = 0; i < 320; i++)
+        buf[i] = bgc;
+
+    /* Channel bar colors (NES palette) */
+    static const BYTE barColors[5] = { 0x16, 0x12, 0x1A, 0x14, 0x17 };
+    static const char *chanNames[5] = { "Pulse 1", "Pulse 2", "Triangle", "Noise", "DPCM" };
+
+    /* Song name (lines 20-27) */
+    if (line >= 20 && line < 28)
+    {
+        int textRow = line - 20;
+        nsfDrawText(buf, 32, line, NsfHeader.szSongName, textRow, fgc, bgc);
+    }
+    /* Artist (lines 36-43) */
+    else if (line >= 36 && line < 44)
+    {
+        int textRow = line - 36;
+        nsfDrawText(buf, 32, line, NsfHeader.szArtistName, textRow, NesPalette[0x21], bgc);
+    }
+    /* Copyright (lines 52-59) */
+    else if (line >= 52 && line < 60)
+    {
+        int textRow = line - 52;
+        nsfDrawText(buf, 32, line, NsfHeader.szCopyright, textRow, NesPalette[0x21], bgc);
+    }
+    /* Track info (lines 72-79) */
+    else if (line >= 72 && line < 80)
+    {
+        char trackStr[40];
+        /* Show elapsed time MM:SS and play/stop status */
+        int totalSec = NsfFrameCounter / 60;
+        int mm = totalSec / 60;
+        int ss = totalSec % 60;
+        snprintf(trackStr, sizeof(trackStr), "Track %d / %d  %d:%02d %s",
+                 NsfCurrentTrack + 1, NsfHeader.byTotalSongs,
+                 mm, ss, NsfIsPlaying ? ">" : "||");
+        int textRow = line - 72;
+        nsfDrawText(buf, 32, line, trackStr, textRow, NesPalette[0x30], bgc);
+    }
+    /* VU bars: 5 channels, each occupies 20 lines (8 label + 8 bar + 4 gap) */
+    else if (line >= 96 && line < 196)
+    {
+        for (int ch = 0; ch < 5; ch++)
+        {
+            int labelStart = 96 + ch * 20;
+            int barStart = labelStart + 8;
+
+            /* Channel label */
+            if (line >= labelStart && line < labelStart + 8)
+            {
+                int textRow = line - labelStart;
+                nsfDrawText(buf, 32, line, chanNames[ch], textRow, NesPalette[barColors[ch]], bgc);
+            }
+            /* VU bar */
+            else if (line >= barStart && line < barStart + 8)
+            {
+                /* Bar width proportional to VU level (0-255 → 0-240 pixels) */
+                int barWidth = (NsfVuLevels[ch] * 240) / 255;
+                WORD barColor = NesPalette[barColors[ch]];
+                for (int x = 40; x < 40 + barWidth && x < 280; x++)
+                    buf[x] = barColor;
+            }
+        }
+    }
+    /* Progress bar (lines 210-215) */
+    else if (line >= 210 && line < 216)
+    {
+        BYTE progress = nsfGetProgress();
+        int barWidth = (progress * 240) / 255;
+        WORD borderColor = NesPalette[0x10]; /* Dark grey */
+        WORD fillColor = NesPalette[0x30];   /* White */
+
+        /* Draw border on top/bottom lines, fill on interior */
+        if (line == 210 || line == 215)
+        {
+            for (int x = 39; x <= 280; x++)
+                buf[x] = borderColor;
+        }
+        else
+        {
+            buf[39] = borderColor;
+            buf[280] = borderColor;
+            for (int x = 40; x < 40 + barWidth && x < 280; x++)
+                buf[x] = fillColor;
+        }
+    }
+}
+
 void __not_in_flash_func(InfoNES_PreDrawLine)(int line)
 {
 #if !HSTX
@@ -1147,6 +1368,19 @@ void __not_in_flash_func(InfoNES_PostDrawLine)(int line)
     drawWorkMeter(line);
 #endif
 #endif
+
+    /* NSF mode: overwrite scanline with VU meter UI */
+    if (IsNSF)
+    {
+        WORD *buf =
+#if !HSTX
+            currentLineBuf == nullptr ? currentLineBuffer_->data() : currentLineBuf;
+#else
+            currentLineBuffer_;
+#endif
+        nsfRenderLine(buf, line);
+    }
+
     // Display frame rate
     if (settings.flags.displayFrameRate && line >= 8 && line < 16)
     {
@@ -1282,9 +1516,9 @@ int main()
         if (strlen(selectedRom) == 0)
         {
 #if PICO_RP2350
-            const char *romExtensions = Frens::isPsramEnabled() ? ".nes .fds" : ".nes";
+            const char *romExtensions = Frens::isPsramEnabled() ? ".nes .fds .nsf" : ".nes .nsf";
 #else
-            const char *romExtensions = ".nes";
+            const char *romExtensions = ".nes .nsf";
 #endif
             menu("Pico-InfoNES+", ErrorMessage, isFatalError, showSplash, romExtensions, selectedRom); // With no psram this never returns, but reboots upon selecting a game
             printf("Playing selected ROM from menu: %s\n", selectedRom);
@@ -1307,7 +1541,7 @@ int main()
             printf("Now playing: %s\n", selectedRom);
         }
        
-        if (isAutoSaveStateConfigured())
+        if (isAutoSaveStateConfigured() && !IsNSF)
         {
             char tmpPath[40];
             getAutoSaveStatePath(tmpPath, sizeof(tmpPath));
@@ -1333,7 +1567,11 @@ int main()
             }
             else
 #endif
-            if (!romSelector_.init(ROM_FILE_ADDR) ) {
+            if (checkNSFMagic(reinterpret_cast<const uint8_t *>(ROM_FILE_ADDR)))
+            {
+                romSelector_.initRaw(ROM_FILE_ADDR);
+            }
+            else if (!romSelector_.init(ROM_FILE_ADDR) ) {
                 strcpy(ErrorMessage, "Not a NES ROM file.");
                 break;
             }

--- a/main.cpp
+++ b/main.cpp
@@ -98,8 +98,8 @@ int8_t g_settings_visibility_nes[MOPT_COUNT] = {
     0,                               // Border Mode (Super Gameboy style borders not applicable for NES)
     1,                               // Rapid Fire on A
     1,                               // Rapid Fire on B
-    1,                               // Enter bootsel mode
     0,                               // Auto Swap FDS, determined by Frens::isPsramEnabled() at runtime since it depends on whether PSRAM is available for loading the disk image
+    1,                               // Enter bootsel mode
     0                                // FDS Disk Swap (toggled on after fdsParse succeeds)
 };
 // #if defined(__riscv)

--- a/main.cpp
+++ b/main.cpp
@@ -99,7 +99,7 @@ int8_t g_settings_visibility_nes[MOPT_COUNT] = {
     1,                               // Rapid Fire on A
     1,                               // Rapid Fire on B
     1,                               // Enter bootsel mode
-    1,                               // Auto Swap FDS
+    0,                               // Auto Swap FDS, determined by Frens::isPsramEnabled() at runtime since it depends on whether PSRAM is available for loading the disk image
     0                                // FDS Disk Swap (toggled on after fdsParse succeeds)
 };
 // #if defined(__riscv)
@@ -1495,6 +1495,7 @@ int main()
     hstx_setScanLines(settings.flags.scanlineOn);
 #endif
     bool showSplash = true;
+    g_settings_visibility_nes[MOPT_AUTO_SWAP_FDS_DISK] = Frens::isPsramEnabled() ? 1 : 0; // FDS disk swap option only relevant when PSRAM is available
     g_settings_visibility = g_settings_visibility_nes;
     g_available_screen_modes = g_available_screen_modes_nes;
     while (true)

--- a/rom_selector.h
+++ b/rom_selector.h
@@ -11,6 +11,11 @@ inline bool checkNESMagic(const uint8_t *data)
     return memcmp(data, "NES\x1a", 4) == 0;
 }
 
+inline bool checkNSFMagic(const uint8_t *data)
+{
+    return memcmp(data, "NESM\x1a", 5) == 0;
+}
+
 inline bool hasNVRAM(const uint8_t *data)
 {
     auto info1 = data[6];


### PR DESCRIPTION
This pull request updates documentation and source files to introduce NSF (Nintendo Sound Format) audio playback support, improve Famicom Disk System (FDS) features, and clarify hardware compatibility and usage instructions. The changes enhance user experience with new features, expanded documentation, and bug fixes, especially for FDS and NSF support.

**Major Feature Additions and Improvements:**

* Added NSF audio playback support, allowing the emulator to load and play `.nsf` music files, with controls for track navigation and playback. Documentation for this feature was added to the `README.md`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R19) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1019-R1055) [[4]](diffhunk://#diff-9ad135e8640751022a0688d45aef13bf444f23488ad8633aece984a4d4cab0a4R10) [[5]](diffhunk://#diff-4bc8434a66473cf59b3cfa728c5eceaa7fd6dde7404a576a769503dfdfbe48f5R42) [[6]](diffhunk://#diff-4bc8434a66473cf59b3cfa728c5eceaa7fd6dde7404a576a769503dfdfbe48f5R474-R482) [[7]](diffhunk://#diff-4bc8434a66473cf59b3cfa728c5eceaa7fd6dde7404a576a769503dfdfbe48f5R569-R574) [[8]](diffhunk://#diff-331279f0500a0df125421502aadfbed93de6bcf5d97004681cb1165c7adf3579R312-R314)
* Improved Famicom Disk System support: implemented save game functionality for games that write data back to disk (e.g., Metroid, Zelda), fixed disk errors and lock-ups, and added an option for automatic disk side swapping. Documentation was expanded and clarified, including requirements and usage instructions. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R51) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L938-R947) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1019-R1055) [[4]](diffhunk://#diff-0e454ed71a0f89d1cfdfbaa7f46b429cdeb7e787d2b8aa1c985e41667050684bR22-R36) [[5]](diffhunk://#diff-0e454ed71a0f89d1cfdfbaa7f46b429cdeb7e787d2b8aa1c985e41667050684bR77-R86)
* Updated and clarified hardware compatibility in `README.md`, including details about PSRAM requirements, supported boards, and issues with certain flash chips. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R188-L195) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L685-R694) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L235-R244)
* Refined the settings menu interface for better usability, including improved layout and clearer color code presentation.

**Documentation and Build System Updates:**

* Expanded documentation for legacy controllers and hardware configurations, including new supported boards and clearer requirements for specific features. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L148-R151) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L121-R124) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L818-R827)
* Updated build script usage instructions and hardware configuration options in the documentation, reflecting new supported boards and features. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1135-R1181) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1190-R1197)
* Improved credits and attributions for external code and AI assistance, specifying contributions to FDS, NSF, and various mapper implementations.

**Bug Fixes:**

* Fixed FDS disk error 24 in Metroid and potential lock-ups in Zelda, improving reliability for FDS games.

**References:** [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R4) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R51) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R19) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1019-R1055) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L938-R947) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R188-L195) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L685-R694) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L235-R244) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L148-R151) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L121-R124) [[11]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L818-R827) [[12]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1135-R1181) [[13]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1190-R1197) [[14]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1236-L1238) [[15]](diffhunk://#diff-9ad135e8640751022a0688d45aef13bf444f23488ad8633aece984a4d4cab0a4R10) [[16]](diffhunk://#diff-4bc8434a66473cf59b3cfa728c5eceaa7fd6dde7404a576a769503dfdfbe48f5R42) [[17]](diffhunk://#diff-4bc8434a66473cf59b3cfa728c5eceaa7fd6dde7404a576a769503dfdfbe48f5R474-R482) [[18]](diffhunk://#diff-4bc8434a66473cf59b3cfa728c5eceaa7fd6dde7404a576a769503dfdfbe48f5R569-R574) [[19]](diffhunk://#diff-331279f0500a0df125421502aadfbed93de6bcf5d97004681cb1165c7adf3579R312-R314) [[20]](diffhunk://#diff-0e454ed71a0f89d1cfdfbaa7f46b429cdeb7e787d2b8aa1c985e41667050684bR22-R36) [[21]](diffhunk://#diff-0e454ed71a0f89d1cfdfbaa7f46b429cdeb7e787d2b8aa1c985e41667050684bR77-R86)