### PR TITLE
Refactor NES settings for screen mode and scanline features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ Famicom Disk System games no longer require PSRAM.
 - Fix NSF pause/resume: preserve elapsed time and prevent false auto-advance on track change.
 - Fix NSF audio delay on PicoDVI boards: send silence audio packets when ring buffer is empty to keep HDMI audio clock stream unbroken, and delay playback start on initial boot to let the monitor lock onto the HDMI signal before audio begins.
 
+**HDMI (HSTX) display**
+
+- Added "Scanline Type" setting (HSTX boards only). Choose between Simple (darken odd lines) and LCD (darken every other output column for a visible pixel grid effect).
+- Added 8:7 pixel aspect ratio support for HSTX boards, matching the NES original display proportions.
+- Screen mode and scanline settings are now unified across DVI and HSTX paths.
+
 **Other**
 
 - Added support for mapper 210 [#200](https://github.com/fhoedemakers/pico-infonesPlus/issues/200)
@@ -38,6 +44,7 @@ Famicom Disk System games no longer require PSRAM.
 - Fix for di_ring_buffer allocated twice in pico_shared/drivers/hdmi/hstx_data_island_queue.c
 - Fix for mapper 19 not working correctly [#200](https://github.com/fhoedemakers/pico-infonesPlus/issues/200)
 - Improved display sync on first launch by feeding blank frames.
+- Fix settings menu always showing unsaved changes due to struct padding mismatch after adding scanline type field.
 
 # v0.41 
 

--- a/main.cpp
+++ b/main.cpp
@@ -84,6 +84,7 @@ int8_t g_settings_visibility_nes[MOPT_COUNT] = {
     0,                               // Save / Restore State
     1,                               // Screen Mode
     0,                               // Scanlines toggle (superseded by Screen Mode)
+    HSTX,                            // Scanline Type (HSTX only)
     1,                               // FPS Overlay
     0,                               // Audio Enable
     0,                               // Frame Skip

--- a/main.cpp
+++ b/main.cpp
@@ -82,8 +82,8 @@ int8_t g_settings_visibility_nes[MOPT_COUNT] = {
     0,                               // Exit Game, or back to menu. Always visible when in-game.
     0,                               // Reset Game
     0,                               // Save / Restore State
-    !HSTX,                           // Screen Mode (only when not HSTX)
-    HSTX,                            // Scanlines toggle (only when HSTX)
+    1,                               // Screen Mode
+    0,                               // Scanlines toggle (superseded by Screen Mode)
     1,                               // FPS Overlay
     0,                               // Audio Enable
     0,                               // Frame Skip
@@ -478,18 +478,10 @@ void InfoNES_PadState(DWORD *pdwPad1, DWORD *pdwPad2, DWORD *pdwSystem)
             }
             if (pushed & UP)
             {
-#if !HSTX
                 scaleMode8_7_ = Frens::screenMode(-1);
-#else
-                Frens::toggleScanLines();
-#endif
             } else if (pushed & DOWN)
             {
-#if !HSTX
                 scaleMode8_7_ = Frens::screenMode(+1);
-#else
-                Frens::toggleScanLines();
-#endif
             } else if (pushed & LEFT)
             {
                 // Toggle audio output, ignore if HSTX is enabled, because HSTX must use external audio
@@ -1445,11 +1437,7 @@ int main()
     //     - Top and bottom margins are reset to zero
     isFatalError = !Frens::initAll(selectedRom, CPUFreqKHz, 4, 4, AUDIOBUFFERSIZE, false, true);
 
-#if !HSTX
     scaleMode8_7_ = Frens::applyScreenMode(settings.screenMode);
-#else
-    hstx_setScanLines(settings.flags.scanlineOn);
-#endif
     bool showSplash = true;
 #if PICO_RP2350
     g_settings_visibility_nes[MOPT_AUTO_SWAP_FDS_DISK] = 1;


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to HDMI (HSTX) display support and the settings menu, along with some codebase cleanup and a submodule update. The most significant changes are the addition of new scanline and aspect ratio options for HSTX boards, unification of display settings, and a fix for a settings menu bug caused by struct padding.

**HDMI (HSTX) display enhancements:**

* Added a "Scanline Type" setting for HSTX boards, allowing users to choose between Simple and LCD scanline effects.
* Introduced 8:7 pixel aspect ratio support for HSTX boards to match NES display proportions.
* Unified screen mode and scanline settings across DVI and HSTX display paths, simplifying display configuration. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR30-R35) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL85-R87) [[3]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL481-L492) [[4]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL1448-L1452)

**Settings menu and bug fixes:**

* Fixed an issue where the settings menu always showed unsaved changes due to a struct padding mismatch after adding the scanline type field.
* Updated settings visibility logic to accommodate the new scanline type option and unified display settings.

**Submodule update:**

* Updated the `pico_shared` submodule to the latest commit, pulling in additional upstream changes.