### PR TITLE
Revert PCB v2.3 changes and restore v2.1 documentation

### DIFF
--- a/.github/workflows/BuildAndRelease.yml
+++ b/.github/workflows/BuildAndRelease.yml
@@ -103,7 +103,7 @@ jobs:
             with:
               files: |
                 releases/*.uf2
-                pico_shared/PCB/pico_nesPCB_v2.3.zip
+                pico_shared/PCB/pico_nesPCB_v2.1.zip
                 pico_shared/PCB/Gerber_PicoNES_Mini_PCB_v2.0.zip
                 pico_shared/PCB/Gerber_PicoNES_Micro_v1.2.zip
                 releases/PicoNesMetadata.zip

--- a/.github/workflows/BuildAndRelease.yml
+++ b/.github/workflows/BuildAndRelease.yml
@@ -103,9 +103,9 @@ jobs:
             with:
               files: |
                 releases/*.uf2
-                PCB/pico_nesPCB_v2.1.zip
-                PCB/Gerber_PicoNES_Mini_PCB_v2.0.zip
-                PCB/Gerber_PicoNES_Micro_v1.2.zip
+                pico_shared/PCB/pico_nesPCB_v2.3.zip
+                pico_shared/PCB/Gerber_PicoNES_Mini_PCB_v2.0.zip
+                pico_shared/PCB/Gerber_PicoNES_Micro_v1.2.zip
                 releases/PicoNesMetadata.zip
               body_path: CHANGELOG.md
           

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ CMakePresets.json
 /pimoroni-pico/
 # Prerequisites
 *.d
-
+releases*/
 # Compiled Object files
 *.slo
 *.lo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-VRC7 FM audio for Lagrange Point, a new overclock setting, a controller test screen, more reliable HDMI audio, support for the new pico-bootLoader bootloader. Updated PCB design for Pico/Pico2 and Pimoroni Pico Plus 2
+VRC7 FM audio for Lagrange Point, a new overclock setting, a controller test screen, more reliable HDMI audio, support for the new pico-bootLoader bootloader. Updated PCB design for Pico/Pico2, now also usable with a Pimoroni Pico Plus 2.
 
 
 # General Info
@@ -36,7 +36,7 @@ VRC7 FM audio for Lagrange Point, a new overclock setting, a controller test scr
 
 ## PCB
 
-Updated PCB **pico_nesPCB_v2.3.zip** includes through-holes, allowing a Raspberry Pi Pico, Pico 2, or [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) **with pin headers** installed to be used.
+Updated PCB **pico_nesPCB_v2.3.zip** includes through-holes, allowing a Raspberry Pi Pico, Pico 2, or [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) **with pin headers** installed to be used. Soldering a headerless Pico or Pico 2 flat onto the board works as before. Earlier designs had no through-holes, which is why the Pico Plus 2 could not be used: its SP/CE connector on the back is in the way when the board lies flat.
 
 ## pico-bootLoader
 
@@ -169,7 +169,7 @@ For some configurations risc-v binaries are available. It is recommended however
 | Pimoroni Pico Plus 2 | [piconesPlus_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_arm.uf2) | [Readme](README.md#raspberry-pi-pico-or-pico-2-setup-with-adafruit-hardware-and-breadboard) |
 
 
-### PCB Pico/Pico2
+### PCB Pico/Pico2 and Pimoroni Pico Plus 2
 
 | Board | Binary | Readme |
 |:--|:--|:--|
@@ -177,6 +177,7 @@ For some configurations risc-v binaries are available. It is recommended however
 | Pico W| [piconesPlus_AdafruitDVISD_pico_w_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico_w_arm.uf2) | [Readme](README.md#pcb-with-raspberry-pi-pico-or-pico-2) |
 | Pico 2 | [piconesPlus_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_arm.uf2) | [Readme](README.md#pcb-with-raspberry-pi-pico-or-pico-2) |
 | Pico 2 W | [piconesPlus_AdafruitDVISD_pico2_w_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_w_arm.uf2) | [Readme](README.md#pcb-with-raspberry-pi-pico-or-pico-2) |
+| Pimoroni Pico Plus 2 (PCB v2.3 and up, headers required) | [piconesPlus_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_arm.uf2) | [Readme](README.md#pcb-with-raspberry-pi-pico-or-pico-2) |
 
 PCB [pico_nesPCB_v2.3.zip](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/pico_nesPCB_v2.3.zip)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ See also [PSRAM with a non-Winbond flash chip](https://github.com/fhoedemakers/p
 
 Updated PCB **pico_nesPCB_v2.3.zip** includes through-holes, allowing a Raspberry Pi Pico, Pico 2, or [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) **with pin headers** installed to be used. Soldering a headerless Pico or Pico 2 flat onto the board works as before. Earlier designs had no through-holes, which is why the Pico Plus 2 could not be used: its SP/CE connector on the back is in the way when the board lies flat.
 
+When using headers, make sure to download the **latest** 3D printed top case from [Thingiverse](https://www.thingiverse.com/thing:6689537). The Pico sits higher on the board when headers are used, and only the newest top cover leaves room for the USB cable to fit. See also [3D printed case for PCB](https://github.com/fhoedemakers/pico-infonesPlus#3d-printed-case-for-pcb) in the readme.
+
 ## pico-bootLoader
 
 - The emulator can now be built to run under the new [pico-bootLoader](https://github.com/fhoedemakers/pico-bootLoader) bootloader, which allows multiple emulators to be installed on a single board and selected at startup. Build with `-DBUILD_FOR_BOOTLOADER=ON`, optionally pinning the image to a 2 MB slot with `-DBUILD_FOR_BOOTLOADER_SLOT=N`. These builds show a new **Return to emulator selection** item in the menu. Standalone builds are unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-VRC7 FM audio for Lagrange Point, a new overclock setting, a controller test screen, more reliable HDMI audio, support for the new pico-bootLoader bootloader.
+VRC7 FM audio for Lagrange Point, a new overclock setting, a controller test screen, more reliable HDMI audio, support for the new pico-bootLoader bootloader. Updated PCB design for Pico/Pico2 and Pimoroni Pico Plus 2
 
 
 # General Info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-VRC7 FM audio for Lagrange Point, a new overclock setting, a controller test screen, more reliable HDMI audio, support for the new pico-bootLoader bootloader. Updated PCB design for Pico/Pico2, now also usable with a Pimoroni Pico Plus 2.
+VRC7 FM audio for Lagrange Point, a new overclock setting, a controller test screen, more reliable HDMI audio, support for the new pico-bootLoader bootloader.
 
 
 # General Info
@@ -43,12 +43,6 @@ See also [PSRAM with a non-Winbond flash chip](https://github.com/fhoedemakers/p
 ## HDMI
 
 - More reliable HDMI audio on HSTX boards: audio packets are now scheduled precisely against the video clock and carry proper IEC 60958 channel-status data. This fixes audio dropouts and improves compatibility with picky TVs and AV receivers.
-
-## PCB
-
-Updated PCB **pico_nesPCB_v2.3.zip** includes through-holes, allowing a Raspberry Pi Pico, Pico 2, or [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) **with pin headers** installed to be used. Soldering a headerless Pico or Pico 2 flat onto the board works as before. Earlier designs had no through-holes, which is why the Pico Plus 2 could not be used: its SP/CE connector on the back is in the way when the board lies flat.
-
-When using headers, make sure to download the **latest** 3D printed top case from [Thingiverse](https://www.thingiverse.com/thing:6689537). The Pico sits higher on the board when headers are used, and only the newest top cover leaves room for the USB cable to fit. See also [3D printed case for PCB](https://github.com/fhoedemakers/pico-infonesPlus#3d-printed-case-for-pcb) in the readme.
 
 ## pico-bootLoader
 
@@ -183,7 +177,7 @@ For some configurations risc-v binaries are available. It is recommended however
 | Pimoroni Pico Plus 2 | [piconesPlus_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_arm.uf2) | [Readme](README.md#raspberry-pi-pico-or-pico-2-setup-with-adafruit-hardware-and-breadboard) |
 
 
-### PCB Pico/Pico2 and Pimoroni Pico Plus 2
+### PCB Pico/Pico2
 
 | Board | Binary | Readme |
 |:--|:--|:--|
@@ -191,9 +185,8 @@ For some configurations risc-v binaries are available. It is recommended however
 | Pico W| [piconesPlus_AdafruitDVISD_pico_w_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico_w_arm.uf2) | [Readme](README.md#pcb-with-raspberry-pi-pico-or-pico-2) |
 | Pico 2 | [piconesPlus_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_arm.uf2) | [Readme](README.md#pcb-with-raspberry-pi-pico-or-pico-2) |
 | Pico 2 W | [piconesPlus_AdafruitDVISD_pico2_w_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_w_arm.uf2) | [Readme](README.md#pcb-with-raspberry-pi-pico-or-pico-2) |
-| Pimoroni Pico Plus 2 (PCB v2.3 and up, headers required) | [piconesPlus_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_arm.uf2) | [Readme](README.md#pcb-with-raspberry-pi-pico-or-pico-2) |
 
-PCB [pico_nesPCB_v2.3.zip](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/pico_nesPCB_v2.3.zip)
+PCB [pico_nesPCB_v2.1.zip](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/pico_nesPCB_v2.1.zip)
 
 3D-printed case designs for PCB:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ VRC7 FM audio for Lagrange Point, a new overclock setting, a controller test scr
 
 - More reliable HDMI audio on HSTX boards: audio packets are now scheduled precisely against the video clock and carry proper IEC 60958 channel-status data. This fixes audio dropouts and improves compatibility with picky TVs and AV receivers.
 
+## PCB
+
+Updated PCB **pico_nesPCB_v2.3.zip** includes through-holes, allowing a Raspberry Pi Pico, Pico 2, or [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) **with pin headers** installed to be used.
+
 ## pico-bootLoader
 
 - The emulator can now be built to run under the new [pico-bootLoader](https://github.com/fhoedemakers/pico-bootLoader) bootloader, which allows multiple emulators to be installed on a single board and selected at startup. Build with `-DBUILD_FOR_BOOTLOADER=ON`, optionally pinning the image to a 2 MB slot with `-DBUILD_FOR_BOOTLOADER_SLOT=N`. These builds show a new **Return to emulator selection** item in the menu. Standalone builds are unchanged.
@@ -174,7 +178,7 @@ For some configurations risc-v binaries are available. It is recommended however
 | Pico 2 | [piconesPlus_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_arm.uf2) | [Readme](README.md#pcb-with-raspberry-pi-pico-or-pico-2) |
 | Pico 2 W | [piconesPlus_AdafruitDVISD_pico2_w_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_w_arm.uf2) | [Readme](README.md#pcb-with-raspberry-pi-pico-or-pico-2) |
 
-PCB [pico_nesPCB_v2.1.zip](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/pico_nesPCB_v2.1.zip)
+PCB [pico_nesPCB_v2.3.zip](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/pico_nesPCB_v2.3.zip)
 
 3D-printed case designs for PCB:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ VRC7 FM audio for Lagrange Point, a new overclock setting, a controller test scr
 
 [See setup section in readme how to install and wire up](https://github.com/fhoedemakers/pico-infonesPlus#pico-setup)
 
+## PSRAM with a non-Winbond flash chip
+
+Applies to any release. Some RP2350 boards, notably the Waveshare RP2350-PiZero, ship with a flash chip from a manufacturer other than Winbond, such as Puya. These chips leave the Quad Enable (QE) bit in Status Register 2 unset from the factory, which makes the board lock up once the RP2350 is overclocked ([#191](https://github.com/fhoedemakers/pico-infonesPlus/issues/191)). Boards **without** PSRAM are not affected.
+
+This can be fixed permanently with the [flash_config](https://github.com/fhoedemakers/flash_config) tool: flash **[FLASH_QE_SET_1.uf2](https://github.com/fhoedemakers/flash_config/blob/main/uf2/FLASH_QE_SET_1.uf2)** once via BOOTSEL, then flash the emulator as usual.
+
+Two things to keep in mind: `FLASH_QE_SET_1.uf2` must not be applied twice (recovery then requires erasing the flash with `universal_flash_nuke.uf2` first), and even after the fix these boards top out at 252 MHz — so the **Overclock** setting, and with it the VRC7 audio of *Lagrange Point (JP)*, cannot be used on them.
+
+See also [PSRAM with a non-Winbond flash chip](https://github.com/fhoedemakers/pico-infonesPlus#psram-with-a-non-winbond-flash-chip) in the readme.
+
 # v0.44
 
 ## Game support
@@ -155,7 +165,9 @@ For some configurations risc-v binaries are available. It is recommended however
 | Adafruit Metro RP2350 | [piconesPlus_AdafruitMetroRP2350_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitMetroRP2350_arm.uf2) | [Readme](README.md#adafruit-metro-rp2350) | |
 | Adafruit Fruit Jam | [piconesPlus_AdafruitFruitJam_arm_piousb.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitFruitJam_arm_piousb.uf2) | [Readme](README.md#adafruit-fruit-jam)| |
 | Waveshare RP2040-PiZero | [piconesPlus_WaveShareRP2040PiZero_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_WaveShareRP2040PiZero_arm.uf2) | [Readme](README.md#waveshare-rp2040rp2350-pizero-development-board)| [3-D Printed case](README.md#3d-printed-case-for-rp2040rp2350-pizero) |
-| Waveshare RP2350-PiZero | [piconesPlus_WaveShareRP2350PiZero_arm_piousb.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_WaveShareRP2350PiZero_arm_piousb.uf2) | [Readme](README.md#waveshare-rp2040rp2350-pizero-development-board)| [3-D Printed case](README.md#3d-printed-case-for-rp2040rp2350-pizero) |
+| Waveshare RP2350-PiZero (*) | [piconesPlus_WaveShareRP2350PiZero_arm_piousb.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_WaveShareRP2350PiZero_arm_piousb.uf2) | [Readme](README.md#waveshare-rp2040rp2350-pizero-development-board)| [3-D Printed case](README.md#3d-printed-case-for-rp2040rp2350-pizero) |
+
+(*) If you fitted this board with PSRAM and it has a non-Winbond flash chip, apply the [flash_config fix](#psram-with-a-non-winbond-flash-chip) before flashing the emulator.
 
 ### Breadboard
 
@@ -196,8 +208,9 @@ For the latest two player PCB 2.0, you need:
 | Board | Binary | Readme |
 |:--|:--|:--|
 | Waveshare RP2040-Zero | [piconesPlus_WaveShareRP2040ZeroWithPCB_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_WaveShareRP2040ZeroWithPCB_arm.uf2) | [Readme](README.md#pcb-with-waveshare-rp2040rp2350-zero) |
-| Waveshare RP2350-Zero | [piconesPlus_WaveShareRP2350ZeroWithPCB_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_WaveShareRP2350ZeroWithPCB_arm.uf2) | [Readme](README.md#pcb-with-waveshare-rp2040rp2350-zero) |
+| Waveshare RP2350-Zero (*) | [piconesPlus_WaveShareRP2350ZeroWithPCB_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_WaveShareRP2350ZeroWithPCB_arm.uf2) | [Readme](README.md#pcb-with-waveshare-rp2040rp2350-zero) |
 
+(*) If you fitted this board with PSRAM and it has a non-Winbond flash chip, apply the [flash_config fix](#psram-with-a-non-winbond-flash-chip) before flashing the emulator.
 
 PCB: [Gerber_PicoNES_Mini_PCB_v2.0.zip](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/Gerber_PicoNES_Mini_PCB_v2.0.zip)
 
@@ -206,6 +219,8 @@ PCB: [Gerber_PicoNES_Mini_PCB_v2.0.zip](https://github.com/fhoedemakers/pico-inf
 
 ### PCB Waveshare RP2350-USBA with PCB
 [Binary](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_WaveShare2350USBA_arm_piousb.uf2)
+
+If you fitted this board with PSRAM and it has a non-Winbond flash chip, apply the [flash_config fix](#psram-with-a-non-winbond-flash-chip) before flashing the emulator.
 
 PCB: [Gerber_PicoNES_Micro_v1.2.zip](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/Gerber_PicoNES_Micro_v1.2.zip)
 

--- a/PCB/README.md
+++ b/PCB/README.md
@@ -1,4 +1,5 @@
-The file **pico_nesPCB_v2.2.zip** in this folder is the current PCB release, as found on the [releases](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest) page. This zip file contains the Gerber files and can be uploaded to a PCB manufacturer of choice.
+> [!NOTE]
+> The design files in this folder are no longer maintained here. The current PCB release, **pico_nesPCB_v2.3.zip**, and all other gerbers now live in the [PCB folder of the pico_shared repository](https://github.com/fhoedemakers/pico_shared/tree/main/PCB). They are also attached to the [releases](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest) page. The files below are kept for reference only.
 
 **pico_nesPCB_v2.1.zip** is identical to v2.0, except that D3 and D4 of NES controller port 2 are mapped to GPIO28 (D3) and GPIO27 (D4). This is intended for possible zapper use, which is currently in beta.
 

--- a/PCB/README.md
+++ b/PCB/README.md
@@ -1,5 +1,5 @@
 > [!NOTE]
-> The design files in this folder are no longer maintained here. The current PCB release, **pico_nesPCB_v2.3.zip**, and all other gerbers now live in the [PCB folder of the pico_shared repository](https://github.com/fhoedemakers/pico_shared/tree/main/PCB). They are also attached to the [releases](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest) page. The files below are kept for reference only.
+> The design files in this folder are no longer maintained here. The current PCB release, **pico_nesPCB_v2.1.zip**, and all other gerbers now live in the [PCB folder of the pico_shared repository](https://github.com/fhoedemakers/pico_shared/tree/main/PCB). They are also attached to the [releases](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest) page. The files below are kept for reference only.
 
 **pico_nesPCB_v2.1.zip** is identical to v2.0, except that D3 and D4 of NES controller port 2 are mapped to GPIO28 (D3) and GPIO27 (D4). This is intended for possible zapper use, which is currently in beta.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Click on image below to see a demo video.
 
 You can use it with these RP2040/RP2350 boards and configurations:
     
-  - A custom printed circuit board (PCB) designed by [@johnedgarpark](https://twitter.com/johnedgarpark). (requires soldering) Up to two NES controller ports can be added to this PCB. Can also be used with a USB gamecontroller. You can 3d print your own NES-like case for the PCB. The Pimoroni Pico Plus 2 is not suitable for this PCB because of the SP/CE connector on back of the board
+  - A custom printed circuit board (PCB) designed by [@johnedgarpark](https://twitter.com/johnedgarpark). (requires soldering) Up to two NES controller ports can be added to this PCB. Can also be used with a USB gamecontroller. You can 3d print your own NES-like case for the PCB. The current design (v2.3) has through-holes, so besides a Raspberry Pi Pico or Pico 2 you can also use a Pimoroni Pico Plus 2, as long as it has soldered male headers.
     
   - An additional PCB design for Waveshare RP2040 & RP2350 Zero including case design by DynaMight1124 based around cheaper but harder to solder components for those that fancy a bigger challenge. It also allows the design to be smaller.
 
@@ -97,7 +97,7 @@ You can use it with these RP2040/RP2350 boards and configurations:
 
 - [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107)
 
-  Use the breadboard config as mentioned above. Works also on the discontinued Pimoroni Pico DV Demo base. This board does not fit the PCB because of the SP/CE connector on back of the board.
+  Use the breadboard config as mentioned above. Works also on the discontinued Pimoroni Pico DV Demo base. Since PCB design v2.3 this board also fits the [custom PCB](#pcb-with-raspberry-pi-pico-or-pico-2), provided male headers are soldered onto it.
   The PSRAM on the board is used in stead of flash to load the roms from SD.
 
 - [Adafruit Fruit Jam](https://www.adafruit.com/product/6200)
@@ -820,7 +820,10 @@ I personally recommend [PCBWay](https://www.pcbway.com/). The boards i ordered f
 
 [![Image](assets/pcbw.png)](https://www.pcbway.com/)
 
-When ordering, simply upload the zip file containing the gerber design.  This file (pico_nesPCB_v2.3.zip) is available in the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest) and can also be found in the [pico_shared/PCB](pico_shared/PCB/) folder. 
+When ordering, simply upload the zip file containing the gerber design.  This file (pico_nesPCB_v2.3.zip) is available in the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest) and can also be found in the [PCB folder of the pico_shared repository](https://github.com/fhoedemakers/pico_shared/tree/main/PCB). 
+
+> [!NOTE]
+> Design v2.3 adds through-holes for the Pico. You can either solder the board flat onto the PCB as before, or plug in a Raspberry Pi Pico, Pico 2 or [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) fitted with male headers. Designs up to and including v2.1 have no through-holes and require the board to be soldered flat.
 
 > [!NOTE]
 >  Soldering skills are required. Make sure you solder all the connections from the Pico onto the PCB. Also the connections on the short right-side of the Pico. (For ground)
@@ -833,7 +836,9 @@ When ordering, simply upload the zip file containing the gerber design.  This fi
 
 Other materials needed:
 
-- Raspberry Pi Pico or Pico 2 **with no headers**.
+- One of the following, depending on how you want to mount it onto the PCB:
+  * Raspberry Pi Pico or Pico 2 **with no headers**, soldered flat onto the PCB. Works with every design version.
+  * Raspberry Pi Pico, Pico 2 or [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) **with soldered male headers**, plugged into the through-holes. Requires design v2.3 or later, see the note above. You can use [these headers](https://a.co/d/dSNPuyo).
 - [Adafruit DVI Breakout Board - For HDMI Source Devices](https://www.adafruit.com/product/4984)
 - [Adafruit Micro SD SPI or SDIO Card Breakout Board - 3V ONLY!](https://www.adafruit.com/product/4682)
 - For the NES Controllers:
@@ -847,7 +852,7 @@ When using a Pico / Pico W, Flash **[piconesPlus_AdafruitDVISD_pico_arm.uf2](htt
 When using a Pico 2 or Pico 2 W, flash **[piconesPlus_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_arm.uf2)** / **[piconesPlus_AdafruitDVISD_pico2_w_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_w_arm.uf2)** instead.
 
 > [!IMPORTANT]
-> You cannot use a [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) because of the SP/CE connector on the back of the board.
+> A [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) can only be used with design v2.3 or later, and only when male headers are soldered onto it. On v2.1 and older designs the board has to lie flat on the PCB, which the SP/CE connector on the back of the Pico Plus 2 prevents.
 
 ### Image: Two player setup using two NES controllers or a USB controller and a NES controller
 
@@ -887,7 +892,7 @@ I personally recommend [PCBWay](https://www.pcbway.com/). The boards I ordered f
 
 [![Image](assets/pcbw.png)](https://www.pcbway.com/)
 
-When ordering, simply upload the zip file containing the gerber design.  This file (Gerber_PicoNES_Mini_PCB_v2.0.zip) is available in the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest) and can also be found in the [PCB](PCB/) folder. 
+When ordering, simply upload the zip file containing the gerber design.  This file (Gerber_PicoNES_Mini_PCB_v2.0.zip) is available in the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest) and can also be found in the [PCB folder of the pico_shared repository](https://github.com/fhoedemakers/pico_shared/tree/main/PCB). 
 
 > [!NOTE]
 >  Soldering skills are required. Make sure you solder all the connections from the Pico onto the PCB. This version requires good soldering skills especially for the HDMI portion, a good amount of flux and a fine tip will be required, additional solder can be wicked away with solder wick. I recommend starting with the resistor arrays first, then the HDMI port, after that either Pico or MicroSD adaptor, lastly the NES Ports, which can be hard to push into the PCB.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 - **Multi-Region Support** – NTSC, PAL, and Dendy region compatibility
 - **NSF Audio Playback** – Play NES music files (`.nsf`) with visual VU-meter overlay. More info on this in the [Playing NSF Audio Files](#playing-nsf-audio-files) section below.
 - **WAV Audio Playback** – WAV (`.wav`) format audio playback in the menu (RP2350 only). More info on this in the [WAV Music Playback in Menu](#wav-music-playback-in-menu-rp2350-only) section below.
-- **Flexible Hardware** – [Compatible with standard DVI/HDMI breakout boards](#possible-configurations), with optional [custom PCB](#pcb-with-raspberry-pi-pico-or-pico-2) and [3D-printed case](https://github.com/fhoedemakers/pico-infonesPlus#3d-printed-case)
+- **Flexible Hardware** – [Compatible with standard DVI/HDMI breakout boards](#possible-configurations), with optional [custom PCB](#pcb-with-raspberry-pi-pico-or-pico-2) and [3D-printed case](#3d-printed-case-for-pcb)
+- **Multi-Emulator Console** – Can run under [pico-bootLoader](#running-under-pico-bootloader) alongside other emulators and Doom, selectable from an on-screen menu (RP2350 only)
 
 
 
@@ -30,7 +31,7 @@
 ### Setup Overview
 
 1. Prepare an SD card formatted as FAT32 or exFAT
-2. Transfer NES ROM files to the card, preferably in /roms/NES (subdirectory organization is supported).
+2. Transfer NES ROM files to the card. The file browser starts in `/roms/NES`, so this is the recommended location. If that folder does not exist, the browser falls back to the root of the card. Subfolders are supported.
 3. Optionally include [metadata files](#using-metadata) for game information
 4. Insert the SD card into the device
 5. Use the menu to browse, select, and play games. Save data is automatically persisted to the SD card.
@@ -59,6 +60,7 @@ There is also an emulator port for the Sega Master System/Sega Game Gear, Ninten
 - Nintendo DMG Game Boy and Game Boy Color: [https://github.com/fhoedemakers/pico-peanutGB](https://github.com/fhoedemakers/pico-peanutGB)
 - Sega Mega Drive/Genesis: [https://github.com/fhoedemakers/pico-genesisPlus](https://github.com/fhoedemakers/pico-genesisPlus)
 - If you have an [Adafruit Fruit Jam](https://www.adafruit.com/product/6200): See this multi emulator project: https://github.com/fhoedemakers/retroJam. Plays NES, Game Boy, Game Boy Color, Sega Master System, Sega Game Gear and Sega Genesis.
+- On any supported RP2350 board, [pico-bootLoader](https://github.com/fhoedemakers/pico-bootLoader) lets you install this emulator next to the ones above and pick between them from an on-screen menu. See [Running under pico-bootLoader](#running-under-pico-bootloader).
 
 ***
 
@@ -73,13 +75,13 @@ Click on image below to see a demo video.
 
 You can use it with these RP2040/RP2350 boards and configurations:
     
-  - A custom printed circuit board (PCB) designed by [@johnedgarpark](https://twitter.com/johnedgarpark). (requires soldering) Up to two NES controller ports can be added to this PCB. Can also be used with a USB gamecontroller. You can 3d print your own NES-like case for the PCB. The current design (v2.3) has through-holes, so besides a Raspberry Pi Pico or Pico 2 you can also use a Pimoroni Pico Plus 2, as long as it has soldered male headers.
+  - A custom printed circuit board (PCB) designed by [@johnedgarpark](https://twitter.com/johnedgarpark). (requires soldering) Up to two NES controller ports can be added to this PCB. Can also be used with a USB game controller. You can 3D print your own NES-like case for the PCB. The current design (v2.3) has through-holes, so besides a Raspberry Pi Pico or Pico 2 you can also use a Pimoroni Pico Plus 2, as long as it has soldered male headers.
     
   - An additional PCB design for Waveshare RP2040 & RP2350 Zero including case design by DynaMight1124 based around cheaper but harder to solder components for those that fancy a bigger challenge. It also allows the design to be smaller.
 
-  - A further PCB design has also been created for the new Waveshare RP2350 USB A board, this allows a very small PicoNES console to be made using USB control pads only. By far the most challenging to solder, if thats your thing!
+  - A further PCB design has also been created for the new Waveshare RP2350 USB A board, this allows a very small PicoNES console to be made using USB control pads only. By far the most challenging to solder, if that's your thing!
  
-- [Adafruit Feather RP2040 with DVI](https://www.adafruit.com/product/5710) (HDMI) Output Port. For use with a USB gamecontroller, up to two legacy NES controllers, or even a WII classic controller. Requires these addons:
+- [Adafruit Feather RP2040 with DVI](https://www.adafruit.com/product/5710) (HDMI) Output Port. For use with a USB game controller, up to two legacy NES controllers, or even a Wii Classic controller. Requires these add-ons:
   - Breadboard
   - SD reader  (choose one below)
     - [Adafruit Micro-SD breakout board+](https://www.adafruit.com/product/254).
@@ -87,43 +89,39 @@ You can use it with these RP2040/RP2350 boards and configurations:
    
 - [Waveshare RP2040-PiZero Development Board](https://www.waveshare.com/rp2040-pizero.htm)
 
-  For use with a USB gamecontroller, up to two legacy NES controllers, or a WII classic controller. (No soldering requirerd)
+  For use with a USB game controller, up to two legacy NES controllers, or a Wii Classic controller. (No soldering required)
 
-  You can 3d print your own NES-like case for for this board. This does require some soldering.
+  You can 3D print your own NES-like case for this board. This does require some soldering.
 
-- [Waveshare RP2350-PiZero Development Board](https://www.waveshare.com/rp2350-pizero.htm) Supports the optional PSRAM chip. When installed, the emulator loads ROMs from PSRAM instead of flash memory for significantly faster performance. When PSRAM is installed, the board must have a Winbond flash chip installed. See [#191](https://github.com/fhoedemakers/pico-infonesPlus/issues/191) Fully functional even without PSRAM.
+- [Waveshare RP2350-PiZero Development Board](https://www.waveshare.com/rp2350-pizero.htm) Supports the optional PSRAM chip. When installed, the emulator loads ROMs from PSRAM instead of flash memory for significantly faster performance. Boards that combine PSRAM with a non-Winbond flash chip need a one-time fix first, see [PSRAM with a non-Winbond flash chip](#psram-with-a-non-winbond-flash-chip). Fully functional even without PSRAM.
 
 - [Adafruit Metro RP2350](https://www.adafruit.com/product/6003) Supports the optional PSRAM chip. When installed, the emulator loads ROMs from PSRAM instead of flash memory for significantly faster performance. Fully functional even without PSRAM.
 
 - [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107)
 
-  Use the breadboard config as mentioned above. Works also on the discontinued Pimoroni Pico DV Demo base. Since PCB design v2.3 this board also fits the [custom PCB](#pcb-with-raspberry-pi-pico-or-pico-2), provided male headers are soldered onto it.
-  The PSRAM on the board is used in stead of flash to load the roms from SD.
+  Can be used in three ways:
+  - On a breadboard with the [Adafruit DVI Breakout For HDMI Source Devices](https://www.adafruit.com/product/4984) and the [Adafruit Micro-SD breakout board+](https://www.adafruit.com/product/254). For use with a USB game controller or up to two legacy NES controllers. (No soldering required)
+  - On the [custom PCB](#pcb-with-raspberry-pi-pico-or-pico-2), from design v2.3 onwards, provided male headers are soldered onto it.
+  - On the discontinued [Pimoroni Pico DV Demo Base](https://shop.pimoroni.com/products/pimoroni-pico-dv-demo-base?variant=39494203998291) HDMI add-on board. For use with a USB game controller or up to two legacy NES controllers. (NES controller ports require soldering)
+  
+  The PSRAM on the board is used instead of flash to load the ROMs from SD.
 
 - [Adafruit Fruit Jam](https://www.adafruit.com/product/6200)
-No additional hardware is required apart from a USB gamepad. Audio is output through the monitor or the included speaker, with the option to connect external speakers and a Wii Classic controller via Stemma QT. The PSRAM on the board is used in stead of flash to load the roms from SD.
+No additional hardware is required apart from a USB gamepad. Audio is output through the monitor or the included speaker, with the option to connect external speakers and a Wii Classic controller via STEMMA QT. The PSRAM on the board is used instead of flash to load the ROMs from SD.
 
 - [SpotPear HDMI](https://spotpear.com/index/product/detail/id/1207.html)
-See downloads in the releases page for the correct binary to use with this board.
+See the downloads on the releases page for the correct binary to use with this board.
 
 - [Murmulator M1 and M2 boards](https://murmulator.ru).
-See downloads in the releases page for the correct binary to use with these boards.
+See the downloads on the releases page for the correct binary to use with these boards.
 
-- [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) Requires one of these addons:
-  - (Discontinued) [Pimoroni Pico DV Demo Base](https://shop.pimoroni.com/products/pimoroni-pico-dv-demo-base?variant=39494203998291) hdmi add-on board. For use with a USB gamecontroller or up to two a legacy NES controllers. (NES controller ports require soldering)
-  - Breadboard and
-    - [Adafruit DVI Breakout For HDMI Source Devices](https://www.adafruit.com/product/4984)
-    - [Adafruit Micro-SD breakout board+](https://www.adafruit.com/product/254).
-      
-    For use with a USB gamecontroller or up to two legacy NES controllers. (No soldering requirerd)
-
-[See below to see how to setup your specific configuration.](#Setup)
+[See below to see how to set up your specific configuration.](#setup)
 
 
 ***
 
 ## Gamecontroller support
-Depending on the hardware configuration, the emulator supports these gamecontrollers. In some configurations, an USB-Y cable is needed to both connect power and a gamecontroller to the usb-port.
+Depending on the hardware configuration, the emulator supports these game controllers. In some configurations, a USB-Y cable is needed to both connect power and a game controller to the USB port.
 
 ### USB  game Controllers
 - Sony Dual Shock 4
@@ -144,24 +142,25 @@ See also [troubleshooting USB controllers below](#troubleshooting-usb-controller
 #### Optional Second USB-Port for game controller use.
 In some configurations, a second USB port is available for connecting a USB game controller. The built-in USB port remains dedicated to power and firmware flashing, so there is no need for a USB-Y cable.
 
-This feature is enabled by default on the Adafruit Fruit Jam and Waveshare RP2350-PiZero. For other boards, you’ll need to [build the firmware from source](#building-from-source) to enable it, as the pre-built binaries do not include this option.
+This feature is enabled by default on the Adafruit Fruit Jam, the Waveshare RP2350-PiZero and the Waveshare RP2350-USB A. For other boards, you’ll need to [build the firmware from source](#building-from-source) to enable it, as the pre-built binaries do not include this option.
 
 For more info, see [pio_usb.md](pio_usb.md).
 
 ### Legacy controllers
-- One or optional two original NES controllers for two player games.  In some configurations, soldering is required.
-- WII-classic controller: Adafruit Feather RP2040, WaveShare RP2040 Pi-Zero, Adafruit Metro RP2350, Adafruit Fruit Jam boards only
+- One or optionally two original NES controllers for two player games.  In some configurations, soldering is required.
+- Original SNES controllers can be connected to the NES controller port(s) as well. The emulator detects automatically whether an NES or a SNES controller is attached, so no configuration is needed.
+- Wii Classic controller: Adafruit Feather RP2040, WaveShare RP2040 Pi-Zero, Adafruit Metro RP2350, Adafruit Fruit Jam boards only
       
 Parts list for legacy controllers
-  * NES Controller. A second controller port and controller is optional and only needed if you want to play two player games using NES controllers. Two player games can also be played with a USB controller and a NES controller.
+  * NES or SNES controller. A second controller port and controller is optional and only needed if you want to play two player games using legacy controllers. Two player games can also be played with a USB controller and a legacy controller.
     * [NES controller port](https://www.zedlabz.com/products/controller-connector-port-for-nintendo-nes-console-7-pin-90-degree-replacement-2-pack-black-zedlabz)
     * [An original NES controller](https://www.amazon.com/s?k=NES+controller&crid=1CX7W9NQQDF8H&sprefix=nes+controller%2Caps%2C174&ref=nb_sb_noss_1)
 
-  * WII-Classic controller 
+  * Wii Classic controller 
     *  [Adafruit Wii Nunchuck Breakout Adapter - Qwiic / STEMMA QT](https://www.adafruit.com/product/4836)
     *  Adafruit Feather RP2040: [Adafruit STEMMA QT / Qwiic JST SH 4-pin Cable](https://www.adafruit.com/product/4210)
     *  Waveshare RP2040-PiZero Development Board: [STEMMA QT / Qwiic JST SH 4-pin Cable with Premium Female Sockets](https://www.adafruit.com/product/4397)
-    *  [WII Classic wired controller](https://www.amazon.com/s?k=wii-classic+controller)
+    *  [Wii Classic wired controller](https://www.amazon.com/s?k=wii-classic+controller)
 
 ***
 
@@ -184,7 +183,7 @@ When using a USB hub with a Raspberry Pi Pico, you need an OTG USB-Y cable to co
 
 ***
 ## PSRAM
-Some boards support additional memory called PSRAM with a capacity of 8MB On certain boards this comes pre-installed, while on others it is optional and must be soldered manually. When PSRAM is detected, the emulator will automatically make use of it.
+Some boards support additional memory called PSRAM, with a capacity of up to 8 MB. On certain boards this comes pre-installed, while on others it is optional and must be soldered manually. The emulator detects the PSRAM and its size at boot and will automatically make use of it.
 
 Without PSRAM, selecting a game ROM triggers a reboot: the ROM is written to flash memory during startup to prevent the system from locking up. This process is relatively slow, taking several seconds before the game starts.
 
@@ -194,13 +193,29 @@ With PSRAM, this step is no longer needed. Games are loaded directly from the SD
 
 | Board | PSRAM Included |
 |:--|:--|
-| [Waveshare RP2350-PiZero](https://www.waveshare.com/rp2350-pizero.htm) | No – optional, must be soldered ([PSRAM module](https://www.adafruit.com/product/4677)) See also issue [#191](https://github.com/fhoedemakers/pico-infonesPlus/issues/191) |
+| [Waveshare RP2350-PiZero](https://www.waveshare.com/rp2350-pizero.htm) | No – optional, must be soldered ([PSRAM module](https://www.adafruit.com/product/4677)). See [PSRAM with a non-Winbond flash chip](#psram-with-a-non-winbond-flash-chip) |
 | [Adafruit Metro RP2350 with PSRAM](https://www.adafruit.com/product/6267) | Yes – pre-installed |
 | [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2) | Yes – pre-installed |
 | [Adafruit Fruit Jam](https://www.adafruit.com/product/6200) | Yes - pre-installed |
 
+## PSRAM with a non-Winbond flash chip
+
+Some RP2350 boards, notably the Waveshare RP2350-PiZero, ship with a flash chip from a manufacturer other than Winbond, such as Puya. On those chips the Quad Enable (QE) bit in Status Register 2 is not set from the factory. In combination with PSRAM this makes the board lock up when the RP2350 is overclocked, which is what the emulator does. See issue [#191](https://github.com/fhoedemakers/pico-infonesPlus/issues/191).
+
+Boards **without** PSRAM are not affected.
+
+This can be fixed permanently, once, with the [flash_config](https://github.com/fhoedemakers/flash_config) tool:
+
+1. Download the prebuilt **[FLASH_QE_SET_1.uf2](https://github.com/fhoedemakers/flash_config/blob/main/uf2/FLASH_QE_SET_1.uf2)** from the [uf2 folder](https://github.com/fhoedemakers/flash_config/tree/main/uf2) of that repository, or build it yourself from source.
+2. Put the board into BOOTSEL mode and copy the UF2 onto the RPI-RP2 drive.
+3. The program sets the QE bit and prints the flash status registers over USB serial.
+4. Flash the emulator firmware as usual. The fix is permanent and does not need to be repeated.
+
+> [!CAUTION]
+> Do not apply `FLASH_QE_SET_1.uf2` a second time. A repeat run fails and the board then has to be recovered by erasing the flash with `universal_flash_nuke.uf2` first.
+
 > [!NOTE]
-> The Waveshare RP2350-PiZero requires a Winbond flash chip for PSRAM to function correctly with the emulator.  However, some boards ship with a flash chip from a different manufacturer, causing the emulator to crash.  See issue [#191](https://github.com/fhoedemakers/pico-infonesPlus/issues/191).  In this scenario the board can only run the emulator if no PSRAM is installed.
+> Even after the fix, boards with a non-Winbond flash chip are limited to 252 MHz. This means the **Overclock** setting (378 MHz) cannot be used on them, and therefore neither can the VRC7 FM audio of *Lagrange Point (JP)*, which depends on it.
 
 
 
@@ -212,7 +227,7 @@ The emulator overclocks the Pico in order to get the emulator working fast enoug
 
 Use this software at your own risk! I will not be responsible in any way for any damage to your Pico and/or connected peripherals caused by using this software.
 
-I also do not take responsability in any way when damage is caused to the Pico or display due to incorrect wiring or voltages.
+I also do not take responsibility in any way when damage is caused to the Pico or display due to incorrect wiring or voltages.
 
 ***
 
@@ -238,6 +253,11 @@ Click on the link below for your specific board configuration:
   * [Build Guide](#build-guide)
 - (Discontinued) [Raspberry Pi Pico or Pico 2, setup for Pimoroni Pico DV Demo Base](#raspberry-pi-pico-or-pico-2-setup-for-pimoroni-pico-dv-demo-base)
 
+The SpotPear HDMI board and the Murmulator M1/M2 boards are supported as well, but have no setup section here. Flash `piconesPlus_SpotpearHDMI_pico_arm.uf2` / `piconesPlus_SpotpearHDMI_pico2_arm.uf2`, or `piconesPlus_MurmulatorM1_pico_arm.uf2` / `piconesPlus_MurmulatorM1_pico2_arm.uf2` / `piconesPlus_MurmulatorM2_arm.uf2` from the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest) and wire the board according to its own documentation.
+
+> [!NOTE]
+> Several boards also have a RISC-V build available (file names ending in `_riscv`). These are functionally identical to the ARM builds; use the ARM build unless you specifically want to run the RISC-V cores of the RP2350.
+
 ***
 
 ##  Raspberry Pi Pico or Pico 2, setup for Pimoroni Pico DV Demo Base.
@@ -256,12 +276,12 @@ Click on the link below for your specific board configuration:
     - [An original NES controller](https://www.amazon.com/s?k=NES+controller&crid=1CX7W9NQQDF8H&sprefix=nes+controller%2Caps%2C174&ref=nb_sb_noss_1)
     - Optional: A second NES controller port and controller if you want to play two player games.
     - [Dupont wires](https://a.co/d/cJVmnQO)
-    - [Mail or female headers to be soldered on the board](https://a.co/d/dSNPuyo)
+    - [Male or female headers to be soldered on the board](https://a.co/d/dSNPuyo)
 - HDMI Cable.
-- Micro usb power adapter.
-- Micro usb to usb cable when using the Duak Shock 4 controller
-- USB C to USB data cable when using the Sony Dual Sense controller.
-- FAT32 or exFAT formatted Micro SD card with roms you legally own. Roms must have the .nes extension. You can organise your roms into different folders.
+- Micro USB power adapter.
+- Micro USB to USB cable when using the DualShock 4 controller
+- USB C to USB data cable when using the Sony DualSense controller.
+- FAT32 or exFAT formatted Micro SD card with ROMs you legally own. ROMs must have the .nes extension. You can organise your ROMs into different folders.
 
 > [!NOTE]
 > An external speaker can be connected to the audio jack of the Pimoroni Pico DV Demo Base. You can toggle audio output to this jack with SELECT + LEFT. 
@@ -269,7 +289,7 @@ Click on the link below for your specific board configuration:
 ### flashing the Pico
 - When using a Pico / Pico W, download **[piconesPlus_PimoroniDVI_pico_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_PimoroniDVI_pico_arm.uf2)**  from the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest).
 - When using a Pico 2 or Pico 2 W or Pimoroni Pico Plus 2, download **[piconesPlus_PimoroniDVI_pico2_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_PimoroniDVI_pico2_arm.uf2)** from the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest).
-- Push and hold the BOOTSEL button on the Pico, then connect to your computer using a micro usb cable. Release BOOTSEL once the drive RPI-RP2 appears on your computer.
+- Push and hold the BOOTSEL button on the Pico, then connect to your computer using a micro USB cable. Release BOOTSEL once the drive RPI-RP2 appears on your computer.
 - Drag and drop the UF2 file on to the RPI-RP2 drive. The Raspberry Pi Pico will reboot and will now run the emulator.
 
 ### Pinout
@@ -297,23 +317,26 @@ Click on the link below for your specific board configuration:
 
 ![Image](assets/nes-controller-pinout.png)
 
+> [!NOTE]
+> An original SNES controller can be wired to the same pins. The emulator detects automatically whether an NES or a SNES controller is attached.
+
 ### setting up the hardware
 - Disconnect the Pico from your computer.
 - Attach the Pico to the DV Demo Base.
 - Connect the HDMI cable to the Demo base and your monitor.
-- Connect the usb OTG cable to the Pico's usb port.
+- Connect the USB OTG cable to the Pico's USB port.
 - Depending which controller you want to use:
-  - Connect the controller to the other end of the usb OTG.
+  - Connect the controller to the other end of the USB OTG cable.
   - Connect legacy NES controller(s) to NES controller port(s).
 - Insert the SD card into the SD card slot.
-- Connect the usb power adapter to the usb port of the Demo base. (USB POWER)
+- Connect the USB power adapter to the USB port of the Demo base. (USB POWER)
 - Power on the monitor and the Pico
 
-### Image: Usb controller only
+### Image: USB controller only
 
 ![Image](assets/PicoInfoNesPlusPimoroni.jpeg)
 
-### Image: one or two player setup with usb controller and NES controller port 2
+### Image: one or two player setup with USB controller and NES controller port 2
 
 In this image the NES controller port is wired to port 2.
 
@@ -323,7 +346,7 @@ For two player games: Connect a USB controller for player 1 and a NES controller
 
 ![Image](assets/2plpimoronidv.png)
 
-### Image: Two player setup using two NES controllers or a USB controller and a NES controller
+### Two player setup using two NES controllers or a USB controller and a NES controller
 
 Controller port 1 pins must be soldered directly onto the Pico.
 
@@ -333,8 +356,6 @@ For two player games:
 
 - Connect two NES controllers or
 - Connect a USB controller for player 1 and a NES controller for player 2. You can use either NES controller ports.
-
-NOIMAGE - TODO
 
 ***
 
@@ -347,7 +368,7 @@ NOIMAGE - TODO
 - Raspberry Pi Pico or Pico 2 with soldered male headers.
 - [Adafruit DVI Breakout For HDMI Source Devices](https://www.adafruit.com/product/4984)
 - [Adafruit Micro-SD breakout board+](https://www.adafruit.com/product/254)
-- [Micro usb to OTG Y-Cable](https://a.co/d/b9t11rl)
+- [Micro USB to OTG Y-Cable](https://a.co/d/b9t11rl)
 - [Breadboard](https://www.amazon.com/s?k=breadboard&crid=1E5ZFUFWE6HNI&sprefix=breadboard%2Caps%2C167&ref=nb_sb_noss_2)
 - [Breadboard jumper wires](https://a.co/d/2NoWOgK)
 - Controllers (Depending on what you have)
@@ -355,19 +376,19 @@ NOIMAGE - TODO
     - [NES controller port](https://www.zedlabz.com/products/controller-connector-port-for-nintendo-nes-console-7-pin-90-degree-replacement-2-pack-black-zedlabz)
     - [An original NES controller](https://www.amazon.com/s?k=NES+controller&crid=1CX7W9NQQDF8H&sprefix=nes+controller%2Caps%2C174&ref=nb_sb_noss_1)
     - [Dupont male to female wires](https://a.co/d/cJVmnQO)
-  - Dual Shock 4 or Dual Sense Controller.
+  - DualShock 4 or DualSense Controller.
 - HDMI Cable.
-- Micro usb power adapter.
-- Usb C to usb cable when using the Sony Dual Sense controller.
-- Micro usb to usb cable when using a Dual Shock 4.
-- FAT32 or exFAT formatted Micro SD card with roms you legally own. Roms must have the .nes extension. You can organize your roms into different folders.
+- Micro USB power adapter.
+- USB C to USB cable when using the Sony DualSense controller.
+- Micro USB to USB cable when using a DualShock 4.
+- FAT32 or exFAT formatted Micro SD card with ROMs you legally own. ROMs must have the .nes extension. You can organise your ROMs into different folders.
 
 
 
 ### flashing the Pico
 - When using a Pico / Pico W, download **[piconesPlus_AdafruitDVISD_pico_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico_arm.uf2)** / **[piconesPlus_AdafruitDVISD_pico_w_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico_w_arm.uf2)** from the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest).
 - When using a Pico 2 or Pico 2 W, download **[piconesPlus_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_arm.uf2)** / **[piconesPlus_AdafruitDVISD_pico2_w_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_w_arm.uf2)** from the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest).
-- Push and hold the BOOTSEL button on the Pico, then connect to your computer using a micro usb cable. Release BOOTSEL once the drive RPI-RP2 appears on your computer. Or when already powered-on. Press and hold BOOTSEL, then press RUN on the board.
+- Push and hold the BOOTSEL button on the Pico, then connect to your computer using a micro USB cable. Release BOOTSEL once the drive RPI-RP2 appears on your computer. Or, when the board is already powered on, press and hold BOOTSEL, then press RUN on the board.
 - Drag and drop the UF2 file on to the RPI-RP2 drive. The Raspberry Pi Pico will reboot and will now run the emulator.
 
 ### Pinout 
@@ -420,30 +441,33 @@ Use the breadboard to connect all together:
 
 ![Image](assets/nes-controller-pinout.png)
 
+> [!NOTE]
+> An original SNES controller can be wired to the same pins. The emulator detects automatically whether an NES or a SNES controller is attached.
+
 ### setting up the hardware
 
 - Disconnect the Pico from your computer.
 - Attach the Pico to the breadboard.
 - Insert the SD card into the SD card slot.
 - Connect the HDMI cable to the Adafruit HDMI Breakout board and to your monitor.
-- Connect the usb OTG Y-cable to the Pico's usb port.
-- Connect the Micro usb power adapter to the female Micro usb connecter of the OTG Y-Cable.
+- Connect the USB OTG Y-cable to the Pico's USB port.
+- Connect the Micro USB power adapter to the female Micro USB connector of the OTG Y-Cable.
 - Controllers (Depending on what you have)
-  - Connect the USB-controller to the full size female usb port of the OTG Y-Cable.
+  - Connect the USB controller to the full size female USB port of the OTG Y-Cable.
   - Connect your NES controller(s) to the NES controller port(s).
 - Power on the monitor and the Pico
 
 See image below. 
 
 > [!NOTE]
-> The Shotky Diode (VSYS - Pin 39 to breadboard + column) and the wire on breadboard left (+) to right (+) are not necessary, but recommended when powering the Pico from a Raspberry Pi.
+> The Schottky diode (VSYS - Pin 39 to breadboard + column) and the wire on breadboard left (+) to right (+) are not necessary, but recommended when powering the Pico from a Raspberry Pi.
 > [See Chapter 4.6 - Powering the Board of the Raspberry Pi Pico Getting Started guide](https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf) 
 
-### Image: one or two player setup with usb controller and NES controller port
+### Image: one or two player setup with USB controller and NES controller port
 
 In this image the NES controller port is wired to port 1.
 
-For single player games, connect either an USB controller **or** a NES controller. Not both!
+For single player games, connect either a USB controller **or** a NES controller. Not both!
 
 For two player games: Connect a USB controller for player 1 and a NES controller for player 2.
 
@@ -475,15 +499,15 @@ Choose either of the following:
 - [Breadboard jumper wires](https://a.co/d/2NoWOgK)
 - USB-C to USB data cable.
 - HDMI Cable.
-- FAT32 or exFAT formatted Micro SD card with roms you legally own. Roms must have the .nes extension. You can organise your roms into different folders.
+- FAT32 or exFAT formatted Micro SD card with ROMs you legally own. ROMs must have the .nes extension. You can organise your ROMs into different folders.
 - Optional: a push button like [this](https://www.kiwi-electronics.com/nl/drukknop-12mm-10-stuks-403?country=NL&utm_term=403&gclid=Cj0KCQjwho-lBhC_ARIsAMpgMoeZIyZD1ZW5GKC0r7iTBCxEP84dIZLqFfoup1D0XNOnpevkp06oyDoaAojJEALw_wcB).
 
-When using a USB gamecontroller this is needed:
+When using a USB game controller this is needed:
 - [USB C male to micro USB female cable](https://www.amazon.com/Adapter-Connector-Charging-Compatible-Z3-Black/dp/B07Z9FLJG3/ref=sr_1_5?keywords=usb+c+male+to+micro+usb+female&qid=1688473279&sprefix=usb+c+male+to+micro+%2Caps%2C159&sr=8-5)
-- [Micro usb to OTG Y-Cable](https://a.co/d/b9t11rl)
-- Micro usb power adapter
-- Usb C to usb cable when using the Sony Dual Sense controller.
-- Micro usb to usb cable when using a Dual Shock 4.
+- [Micro USB to OTG Y-Cable](https://a.co/d/b9t11rl)
+- Micro USB power adapter
+- USB C to USB cable when using the Sony DualSense controller.
+- Micro USB to USB cable when using a DualShock 4.
 
 When using legacy controllers, this is needed:
   * USB-C Power supply   
@@ -492,10 +516,10 @@ When using legacy controllers, this is needed:
       * [NES controller port](https://www.zedlabz.com/products/controller-connector-port-for-nintendo-nes-console-7-pin-90-degree-replacement-2-pack-black-zedlabz)
       * [An original NES controller](https://www.amazon.com/s?k=NES+controller&crid=1CX7W9NQQDF8H&sprefix=nes+controller%2Caps%2C174&ref=nb_sb_noss_1)
       * [Dupont male to female wires](https://a.co/d/cJVmnQO)
-    * WII-Classic controller
+    * Wii Classic controller
       *  [Adafruit Wii Nunchuck Breakout Adapter - Qwiic / STEMMA QT](https://www.adafruit.com/product/4836)
       *  [Adafruit STEMMA QT / Qwiic JST SH 4-pin Cable](https://www.adafruit.com/product/4210)
-      *  [WII Classic wired controller](https://www.amazon.com/Classic-Controller-Nintendo-Wii-Remote-Console/dp/B0BYNHWS1V/ref=sr_1_1_sspa?crid=1I66OX5L05507&keywords=Wired+WII+Classic+controller&qid=1688119981&sprefix=wired+wii+classic+controller%2Caps%2C150&sr=8-1-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&psc=1)
+      *  [Wii Classic wired controller](https://www.amazon.com/Classic-Controller-Nintendo-Wii-Remote-Console/dp/B0BYNHWS1V/ref=sr_1_1_sspa?crid=1I66OX5L05507&keywords=Wired+WII+Classic+controller&qid=1688119981&sprefix=wired+wii+classic+controller%2Caps%2C150&sr=8-1-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&psc=1)
   
 ### Pinout 
 See: https://learn.adafruit.com/assets/119662 for the Feather pin scheme.
@@ -520,9 +544,9 @@ Use the breadboard to connect all together:
 | GND           |        | - column on breadboard connected to feather ground pin|
 
 > [!NOTE]
-> The Adafruit Micro-SD breakout board+ has also a 3V input pin which can be connected to + column on breadboard connected to feather 3.3V pin. However, this gave me frequently errors trying to mount the SD card. So use 5V in stead.
+> The Adafruit Micro-SD breakout board+ also has a 3V input pin which can be connected to the + column on the breadboard connected to the feather 3.3V pin. However, this frequently gave me errors trying to mount the SD card. So use 5V instead.
 
-#### WII  nunchuck breakout adapter.
+#### Wii nunchuck breakout adapter.
 
 Connect the nunchuck breakout adapter to the Feather DVI using the STEMMA QT cable.
 
@@ -538,8 +562,11 @@ Connect the nunchuck breakout adapter to the Feather DVI using the STEMMA QT cab
 
 ![Image](assets/nes-controller-pinout.png)
 
+> [!NOTE]
+> An original SNES controller can be wired to the same pins. The emulator detects automatically whether an NES or a SNES controller is attached.
+
 ### flashing the Feather RP2040
-- Download **[piconesPlus_FeatherDVI_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_FeatherDVI_arm.uf2)** from the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest).
+- Download **[piconesPlus_AdafruitFeatherDVI_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitFeatherDVI_arm.uf2)** from the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest).
 - Connect the feather to a USB port on your computer using the USB-C data cable.
 - On the feather, push and hold the BOOTSEL button, then press RESET. Release the buttons, the drive RPI-RP2 should appear on your computer.
 - Drag and drop the UF2 file on to the RPI-RP2 drive. The Raspberry Pi Pico will reboot and will now run the emulator.
@@ -555,33 +582,33 @@ Connect the nunchuck breakout adapter to the Feather DVI using the STEMMA QT cab
 - Connect the HDMI cable to the HDMI port of the Adafruit Feather and to your monitor.
 - Connect controllers depending on your setup:
   - Legacy controllers.
-    - NES Controller to the NES controller port.
-    - WII-Classic controller to the Nunchuck Breakout Adapter.
+    - NES controller to the NES controller port.
+    - Wii Classic controller to the Nunchuck Breakout Adapter.
     - Connect USB-C power supply to USB-C connector.
-  - USB game Controllers
-    * Connect the USB C connector of the "male USB C to female micro usb cable" to the USB C port of the feather.
-    * Connect the female micro USB port of the "male USB C to female micro usb cable" to the male micro USB port of the USB OTG Y cable.
-    * Connect the Dual Sense or Dual Shock controller with the appropriate cable to the full size female usb port of the OTG Y-Cable.
-    * Connect the Micro usb power adapter to the female Micro usb connecter of the OTG Y-Cable.
+  - USB game controllers
+    * Connect the USB C connector of the "male USB C to female micro USB cable" to the USB C port of the feather.
+    * Connect the female micro USB port of the "male USB C to female micro USB cable" to the male micro USB port of the USB OTG Y cable.
+    * Connect the DualSense or DualShock controller with the appropriate cable to the full size female USB port of the OTG Y-Cable.
+    * Connect the Micro USB power adapter to the female Micro USB connector of the OTG Y-Cable.
 - Power on the monitor and the Pico
 
-### Image: one or two player setup with usb controller and NES/WII_classic controller port
+### Image: one or two player setup with USB controller and NES/Wii Classic controller port
 
 In this image the NES controller port is wired to port 1.
 
-For single player games, connect either an USB controller **or** a NES/WII-classic controller. Not both!
+For single player games, connect either a USB controller **or** a NES/Wii Classic controller. Not both!
 
-For two player games: Connect a USB controller for player 1 and a NES or WII-Classic controller for player 2.
+For two player games: Connect a USB controller for player 1 and a NES or Wii Classic controller for player 2.
 
 ![Image](assets/featherDVI.jpg)
 
-### Image: Two player setup using two NES controllers or a USB controller and a NES/WII-classic controller
+### Image: Two player setup using two NES controllers or a USB controller and a NES/Wii Classic controller
 
 Choose either of the following:
 
 - Connect two NES controllers
-- Connect a WII-Classic Controller for player 1 and a NES-Controller on port 2 for player 2
-- Connect a USB controller for player 1 and a NES controller for player 2. You can use either NES controller ports. You can also use the WII-classic controller for player 2.
+- Connect a Wii Classic controller for player 1 and a NES controller on port 2 for player 2
+- Connect a USB controller for player 1 and a NES controller for player 2. You can use either NES controller ports. You can also use the Wii Classic controller for player 2.
 
 
 ![Image](assets/2plfeatherdv.png)
@@ -591,7 +618,7 @@ Choose either of the following:
 ## Adafruit Metro RP2350
 
 
-This configuration supports USB-Controller and legacy controllers. (NES / WII-classic). 
+This configuration supports USB controllers and legacy controllers. (NES / SNES / Wii Classic). 
 
 ### Materials needed
 
@@ -601,28 +628,28 @@ This configuration supports USB-Controller and legacy controllers. (NES / WII-cl
 - USB-C power supply. 
 - [USB-C to USB-C - USB-A Y cable.](https://a.co/d/9vCzu0h) when using a USB game controller. The Y-cable is needed to connect the game controller and power the board at the same time.
 - [USB-C to USB-A cable](https://a.co/d/2i7rJid) for flashing the uf2 onto the board 
-- FAT32 or exFAT formatted Micro SD card with roms you legally own. Roms must have the .nes extension. You can organise your roms into different folders.
+- FAT32 or exFAT formatted Micro SD card with ROMs you legally own. ROMs must have the .nes extension. You can organise your ROMs into different folders.
 
 > [!NOTE]
-> Use an USB-c power supply to power the board instead of the barrel jack. Powering the board using the barrel jack can cause usb game controllers to not work properly.
+> Use a USB-C power supply to power the board instead of the barrel jack. Powering the board using the barrel jack can cause USB game controllers to not work properly.
 
 > [!NOTE]
-> You can use the [USB host pins](https://learn.adafruit.com/adafruit-metro-rp2350/pinouts#usb-host-pins-3193156) on the board to connect a usb game-controller instead. Soldering is required for this. You also need to build the binary from source, since it is currently not included in the latest release. For more info see [pio_usb.md](pio_usb.md)
+> You can use the [USB host pins](https://learn.adafruit.com/adafruit-metro-rp2350/pinouts#usb-host-pins-3193156) on the board to connect a USB game controller instead. Soldering is required for this. You also need to build the binary from source, since it is currently not included in the latest release. For more info see [pio_usb.md](pio_usb.md)
 
 
 #### Legacy Controllers
 
  * Depending on what you have:
-    * one or two NES Controllers.
+    * one or two NES controllers.
       * [NES controller port](https://www.zedlabz.com/products/controller-connector-port-for-nintendo-nes-console-7-pin-90-degree-replacement-2-pack-black-zedlabz)
       * [An original NES controller](https://www.amazon.com/s?k=NES+controller&crid=1CX7W9NQQDF8H&sprefix=nes+controller%2Caps%2C174&ref=nb_sb_noss_1)
       * [Dupont male to female wires](https://a.co/d/cJVmnQO)
-    * WII-Classic controller
+    * Wii Classic controller
       *  [Adafruit Wii Nunchuck Breakout Adapter - Qwiic / STEMMA QT](https://www.adafruit.com/product/4836)
       *  [Adafruit STEMMA QT / Qwiic JST SH 4-pin Cable](https://www.adafruit.com/product/4210)
-      *  [WII Classic wired controller](https://www.amazon.com/Classic-Controller-Nintendo-Wii-Remote-Console/dp/B0BYNHWS1V/ref=sr_1_1_sspa?crid=1I66OX5L05507&keywords=Wired+WII+Classic+controller&qid=1688119981&sprefix=wired+wii+classic+controller%2Caps%2C150&sr=8-1-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&psc=1)
+      *  [Wii Classic wired controller](https://www.amazon.com/Classic-Controller-Nintendo-Wii-Remote-Console/dp/B0BYNHWS1V/ref=sr_1_1_sspa?crid=1I66OX5L05507&keywords=Wired+WII+Classic+controller&qid=1688119981&sprefix=wired+wii+classic+controller%2Caps%2C150&sr=8-1-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&psc=1)
 
-#### WII  nunchuck breakout adapter.
+#### Wii nunchuck breakout adapter.
 
 Connect the nunchuck breakout adapter to the Metro using the STEMMA QT cable.
 
@@ -637,6 +664,9 @@ Connect the nunchuck breakout adapter to the Metro using the STEMMA QT cable.
 | NES Data      | GPIO3 | GPIO6 |        |
 
 ![Image](assets/nes-controller-pinout.png)
+
+> [!NOTE]
+> An original SNES controller can be wired to the same pins. The emulator detects automatically whether an NES or a SNES controller is attached.
 
 ### flashing the Adafruit Metro RP2350
 
@@ -660,7 +690,7 @@ The new [Adafruit Fruit Jam](https://www.adafruit.com/product/6200) is supported
 - USB gamepad
 - Power to USB-C
 - Optional
-  * If you want to use a WII-Classic controller:
+  * If you want to use a Wii Classic controller:
     * [Adafruit Wii Nunchuck Breakout Adapter - Qwiic / STEMMA QT](https://www.adafruit.com/product/4836)
     * [Wii Classic controller](https://www.amazon.com/s?k=Wii+Classic+controller&crid=1I66OX5L05507&sprefix=wii+classic+controller%2Caps%2C150&ref=nb_sb_noss_1)
   * External speakers
@@ -669,20 +699,20 @@ The new [Adafruit Fruit Jam](https://www.adafruit.com/product/6200) is supported
 ### Setup
 
 - Connect your USB gamepad to the USB 1 port of the Fruit Jam.
-- If you want to use a WII-Classic controller, connect the nunchuck breakout adapter to the Fruit Jam using the STEMMA QT cable and the Wii Classic controller to the breakout adapter.
+- If you want to use a Wii Classic controller, connect the nunchuck breakout adapter to the Fruit Jam using the STEMMA QT cable and the Wii Classic controller to the breakout adapter.
 - Connect external speakers to the audio output of the Fruit Jam.
 
 To enable audio over HDMI make sure the setting **External audio** is disabled in the options menu.
 
 When **External audio** is enabled, audio will be played through the external speakers and mini speaker simultaneously. Press Button 1 on the Fruit Jam to mute the mini speaker
 
-Flash the firmware onto the Fruit Jam. (Connect Fruit Jam via his USB-C connector to computer, then Hold Reset and Button 1). Copy [piconesPlus_AdafruitFruitJam_arm_piousb.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitFruitJam_arm_piousb.uf2) to the RPI-RP2 drive.
+Flash the firmware onto the Fruit Jam. (Connect the Fruit Jam to your computer via its USB-C connector, then hold Reset and Button 1). Copy [piconesPlus_AdafruitFruitJam_arm_piousb.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitFruitJam_arm_piousb.uf2) to the RPI-RP2 drive.
 
 Please keep the following in mind:
 
 - Not all USB controllers from the [supported controllers](#usb--game-controllers) list are guaranteed to work.
-- Two player mode is only possible with one USB gamepad on USB1 and one WII-Classic controller. USB2 is not supported for two player mode yet, will be looking into it. 
-- When an USB controller is connected, the WII-classic controller is player 2. To use the WII-Classic as player 1, unplug the USB controller.
+- Two player mode is only possible with one USB gamepad on USB1 and one Wii Classic controller. USB2 is not supported for two player mode yet, will be looking into it. 
+- When a USB controller is connected, the Wii Classic controller is player 2. To use the Wii Classic controller as player 1, unplug the USB controller.
 
 <img width="800" height="1204" alt="image" src="https://github.com/user-attachments/assets/b72ee649-e166-47c2-a29d-ad0090b9f262" />
 
@@ -696,22 +726,22 @@ Please keep the following in mind:
 - One of these Waveshare boards:
   - [Waveshare RP2040-PiZero Development Board](https://www.waveshare.com/rp2040-pizero.htm).
   - [Waveshare RP2350-PiZero Development Board](https://www.waveshare.com/rp2350-pizero.htm).
-    - Optional: [PSRAM chip](https://www.adafruit.com/product/4677) When installed, the emulator loads ROMs from PSRAM instead of flash memory for significantly faster performance. Fully functional even without PSRAM. There is an issue with boards usings flash chips from another brand than Winbond, where the PSRAM is not working. See [#191](https://github.com/fhoedemakers/pico-infonesPlus/issues/191)
+    - Optional: [PSRAM chip](https://www.adafruit.com/product/4677) When installed, the emulator loads ROMs from PSRAM instead of flash memory for significantly faster performance. Fully functional even without PSRAM. Boards using a flash chip from a brand other than Winbond need a one-time fix before PSRAM works, see [PSRAM with a non-Winbond flash chip](#psram-with-a-non-winbond-flash-chip).
 - [USB-C to USB-A cable](https://a.co/d/2i7rJid) for flashing the uf2 onto the board.
 - USB-C Power supply. Connect to the port labelled USB, not PIO-USB. See note below.
 - [Mini HDMI to HDMI Cable](https://a.co/d/5BZg3Z6).
-- FAT32 or exFAT formatted Micro SD card with roms you legally own. Roms must have the .nes extension. You can organise your roms into different folders.
+- FAT32 or exFAT formatted Micro SD card with ROMs you legally own. ROMs must have the .nes extension. You can organise your ROMs into different folders.
 
 Additional for the RP2040-Pizero only:
 
-- [USB-C to USB-C - USB-A Y cable](https://a.co/d/eteMZLt). when using an USB controller. Not needed for the Waveshare RP2350-PiZero where the controller **must** be connected to the PIO-USB port.
+- [USB-C to USB-C - USB-A Y cable](https://a.co/d/eteMZLt), when using a USB controller. Not needed for the Waveshare RP2350-PiZero where the controller **must** be connected to the PIO-USB port.
 
 > [!NOTE]
 > Unlike the WaveShare RP2350-PiZero, where the controller must be connected to the PIO-USB port, the WaveShare RP2040-PiZero Development Board cannot use the PIO-USB port for the controller due to memory limitations.  Instead, connect both the controller and the power adapter to the Y-cable, and then plug the Y-cable into the board’s port labeled “USB.” While the PIO-USB port can still be used to power the RP2040 board, I do not recommend this, as it has occasionally caused unstable behavior.
 
 #### NES controller port.
 
-When using a original NES controller you need:
+When using an original NES controller you need:
 
 - [NES controller port](https://www.zedlabz.com/products/controller-connector-port-for-nintendo-nes-console-7-pin-90-degree-replacement-2-pack-black-zedlabz)
 - [An original NES controller](https://www.amazon.com/s?k=NES+controller&crid=1CX7W9NQQDF8H&sprefix=nes+controller%2Caps%2C174&ref=nb_sb_noss_1)
@@ -731,15 +761,18 @@ For two player games with two NES controllers you need an extra NES controller p
 ![Image](assets/nes-controller-pinout.png)
 
 > [!NOTE]
-> Contrary to other configurations where VCC is connected to 3Volt, VCC should be connected to a 5Volt pin. Otherwise the NES controller could possibly not work.
+> An original SNES controller can be wired to the same pins. The emulator detects automatically whether an NES or a SNES controller is attached.
 
-#### WII-Classic controller.
+> [!NOTE]
+> Contrary to other configurations where VCC is connected to 3 volt, VCC should be connected to a 5 volt pin. Otherwise the NES controller may not work.
 
-When using a WII-Classic controller you need:
+#### Wii Classic controller.
+
+When using a Wii Classic controller you need:
 
 -  [Adafruit Wii Nunchuck Breakout Adapter - Qwiic / STEMMA QT](https://www.adafruit.com/product/4836)
 -  [STEMMA QT / Qwiic JST SH 4-pin Cable with Premium Female Sockets](https://www.adafruit.com/product/4397) 
--  [WII Classic wired controller](https://www.amazon.com/s?k=wii-classic+controller)
+-  [Wii Classic wired controller](https://www.amazon.com/s?k=wii-classic+controller)
 
 Connections are as follows:
 
@@ -758,7 +791,7 @@ Connections are as follows:
 
 
 ### flashing the Waveshare RP2350-PiZero Development Board
-- Download **[piconesPlus_WaveShareRP2350PiZero_arm_piousb.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_WaveShareRP2350PiZero_arm_piousb.uf2) | [Readme](README.md#waveshare-rp2040rp2350-pizero-development-board)** from the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest).
+- Download **[piconesPlus_WaveShareRP2350PiZero_arm_piousb.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_WaveShareRP2350PiZero_arm_piousb.uf2)** from the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest).
 - Connect the USB-C port marked USB (not PIO-USB) to a USB port on your computer using the USB-C to USB-A data cable.
 - On the board, push and hold the BOOT button, then press RUN. Release the buttons, the drive RPI-RP2 should appear on your computer.
 - Drag and drop the UF2 file on to the RPI-RP2 drive. The board will reboot and will now run the emulator.
@@ -766,11 +799,11 @@ Connections are as follows:
 > [!NOTE]
 >  When the emulator won't start after flashing or powering on, and the screen shows 'No signal,' press the run button once again. The emulator should now boot.
 
-### Image: one or two player setup with usb controller and NES controller port
+### Image: one or two player setup with USB controller and NES controller port
 
 In this image the NES controller port is wired to port 1.
 
-For single player games, connect either an USB controller **or** a NES controller. Not both!
+For single player games, connect either a USB controller **or** a NES controller. Not both!
 
 For two player games: Connect a USB controller for player 1 and a NES controller for player 2.
 
@@ -787,7 +820,7 @@ Choose either of the following:
 
 ![Image](assets/2plwsrp2040.png)
 
-### Image: Using a wii-classic controller
+### Image: Using a Wii Classic controller
 
 ![WS-Wiiclassic](https://github.com/user-attachments/assets/d5a89389-6b19-42df-9071-f315b4bb1ee5)
 
@@ -797,7 +830,7 @@ Choose either of the following:
 
 ### 3D printed case for RP2040/RP2350-PiZero
 
-Gavin Knight ([DynaMight1124](https://github.com/DynaMight1124)) designed a NES-like case you can 3d-print as an enclosure for this board.  This enclosure is designed for 2 NES controller ports so you can play 1 or 2-player games. [Click here for the design](https://www.thingiverse.com/thing:6758682). Please contact the creator on his Thingiverse page if you have any questions about this case.
+Gavin Knight ([DynaMight1124](https://github.com/DynaMight1124)) designed a NES-like case you can 3D print as an enclosure for this board.  This enclosure is designed for 2 NES controller ports so you can play 1 or 2-player games. [Click here for the design](https://www.thingiverse.com/thing:6758682). Please contact the creator on their Thingiverse page if you have any questions about this case.
 
 ![WS3D1](https://github.com/user-attachments/assets/12e48dfa-4338-4f10-922c-66a016605210)
 
@@ -815,13 +848,13 @@ Designed by [@johnedgarpark](https://twitter.com/johnedgarpark)
 <img width="4284" height="5712" alt="IMG_1551" src="https://github.com/user-attachments/assets/c26edd6f-1407-4f7e-869f-abd8ffe5bae8" />
 
 
-Several Companies  can make these PCBs for you. 
+Several companies can make these PCBs for you. 
 
-I personally recommend [PCBWay](https://www.pcbway.com/). The boards i ordered from them are of excellent quality. They have also a very short lead time. Boards i ordered on Monday arrived from China to my home in the Netherlands on Friday of the same week.
+I personally recommend [PCBWay](https://www.pcbway.com/). The boards I ordered from them are of excellent quality. They also have a very short lead time. Boards I ordered on Monday arrived from China to my home in the Netherlands on Friday of the same week.
 
 [![Image](assets/pcbw.png)](https://www.pcbway.com/)
 
-When ordering, simply upload the zip file containing the gerber design.  This file (pico_nesPCB_v2.3.zip) is available in the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest) and can also be found in the [PCB folder of the pico_shared repository](https://github.com/fhoedemakers/pico_shared/tree/main/PCB). 
+When ordering, simply upload the zip file containing the gerber design.  This file (pico_nesPCB_v2.3.zip) is available on the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest) and can also be found in the [PCB folder of the pico_shared repository](https://github.com/fhoedemakers/pico_shared/tree/main/PCB). 
 
 > [!NOTE]
 > Design v2.3 adds through-holes for the Pico. You can either solder the board flat onto the PCB as before, or plug in a Raspberry Pi Pico, Pico 2 or [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) fitted with male headers. Designs up to and including v2.1 have no through-holes and require the board to be soldered flat.
@@ -833,7 +866,7 @@ When ordering, simply upload the zip file containing the gerber design.  This fi
 > If you are looking for the previous design (v0.2). You can find it [here](PCB/v0.2)
 
 > [!NOTE]
-> Sellers on AliExpress have copied the PCB design and are selling pre-populated PCB's. For questions about those boards, please contact the seller on AliExpress.
+> Sellers on AliExpress have copied the PCB design and are selling pre-populated PCBs. For questions about those boards, please contact the seller on AliExpress.
 
 Other materials needed:
 
@@ -842,16 +875,16 @@ Other materials needed:
   * Raspberry Pi Pico, Pico 2 or [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) **with soldered male headers**, plugged into the through-holes. Requires design v2.3 or later, see the note above. You can use [these headers](https://a.co/d/dSNPuyo).
 - [Adafruit DVI Breakout Board - For HDMI Source Devices](https://www.adafruit.com/product/4984)
 - [Adafruit Micro SD SPI or SDIO Card Breakout Board - 3V ONLY!](https://www.adafruit.com/product/4682)
-- For the NES Controllers:
+- For the NES controllers:
   * [1 or 2 NES controller port(s)](https://www.zedlabz.com/products/controller-connector-port-for-nintendo-nes-console-7-pin-90-degree-replacement-2-pack-black-zedlabz)
   * [1 or 2 NES controller(s)](https://www.amazon.com/s?k=NES+controller&crid=1CX7W9NQQDF8H&sprefix=nes+controller%2Caps%2C174&ref=nb_sb_noss_1)
-- [Micro usb to OTG Y-Cable](https://a.co/d/b9t11rl) if you want to use a Dualshock/Dualsense controller.
+- [Micro USB to OTG Y-Cable](https://a.co/d/b9t11rl) if you want to use a DualShock/DualSense controller.
 - Micro USB power supply.
 - Optional: on/off switch, like [this](https://www.kiwi-electronics.com/en/spdt-slide-switch-410?search=KW-2467) 
 
 When using a Pico / Pico W, Flash **[piconesPlus_AdafruitDVISD_pico_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico_arm.uf2)** / **[piconesPlus_AdafruitDVISD_pico_w_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico_w_arm.uf2)** from the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest). 
 When using a Pico 2 or Pico 2 W, flash **[piconesPlus_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_arm.uf2)** / **[piconesPlus_AdafruitDVISD_pico2_w_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_w_arm.uf2)** instead.
-When using a Pimoroni Pico Plus 2, flash **[piconesPlus_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_arm.uf2)** as well. The PSRAM on the board is used instead of flash to load the roms from SD.
+When using a Pimoroni Pico Plus 2, flash **[piconesPlus_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_arm.uf2)** as well. The PSRAM on the board is used instead of flash to load the ROMs from SD.
 
 > [!IMPORTANT]
 > A [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) can only be used with design v2.3 or later, and only when male headers are soldered onto it. On v2.1 and older designs the board has to lie flat on the PCB, which the SP/CE connector on the back of the Pico Plus 2 prevents.
@@ -861,13 +894,13 @@ When using a Pimoroni Pico Plus 2, flash **[piconesPlus_AdafruitDVISD_pico2_arm.
 Choose either of the following:
 
 - Connect two NES controllers 
-- Connect a USB controller for player 1 and a NES controller for player 2. You can use either NES controller ports. Use the OTG Y-Cable to connect an USB power supply and the USB controller.
+- Connect a USB controller for player 1 and a NES controller for player 2. You can use either NES controller ports. Use the OTG Y-Cable to connect a USB power supply and the USB controller.
 
 ![image0](https://github.com/user-attachments/assets/d40ed98f-4632-4161-986a-732d35290fac)
 
 ### 3D printed case for PCB
 
-Gavin Knight ([DynaMight1124](https://github.com/DynaMight1124)) designed a NES-like case you can 3d-print as an enclosure for this pcb.  You can find it here: [https://www.thingiverse.com/thing:6689537](https://www.thingiverse.com/thing:6689537). Here you can find two designs: the latest design for PCB v2.0  and the previous design for [PCB v0.2](PCB/v0.2). In the latest v2.0 design, you can choose between two top covers, one with a button connecting to the bootsel button for easy firmware upgrades, the other without the button. In this case you have to remove the top cover to access the bootsel button. See images below. Make sure to print the correct files for the PCB version you own. You can find more information on Gavin's Thingiverse page.
+Gavin Knight ([DynaMight1124](https://github.com/DynaMight1124)) designed a NES-like case you can 3D print as an enclosure for this PCB.  You can find it here: [https://www.thingiverse.com/thing:6689537](https://www.thingiverse.com/thing:6689537). Here you can find two designs: the latest design for PCB v2.0  and the previous design for [PCB v0.2](PCB/v0.2). In the latest v2.0 design, you can choose between two top covers, one with a button connecting to the bootsel button for easy firmware upgrades, the other without the button. In this case you have to remove the top cover to access the bootsel button. See images below. Make sure to print the correct files for the PCB version you own. You can find more information on Gavin's Thingiverse page.
 
 #### Top Cover v2.0 without button (Top_v2.0.stl)
 ![Top cover without button](https://github.com/user-attachments/assets/c6205db3-580e-41e9-83e4-66c9534c6519)
@@ -886,29 +919,29 @@ Gavin Knight ([DynaMight1124](https://github.com/DynaMight1124)) designed a NES-
 
 ## PCB with WaveShare RP2040/RP2350 Zero
 
-Create your own Pico-based NES console. It features two NES controller ports for 1 or 2-player games. This version is smaller than the above and uses cheaper, but ultimately harder to solder components. This is a more advanced project than the above PCB design, if you are unsure of your soldering capabilities I wouldnt recommend this PCB.
+Create your own Pico-based NES console. It features two NES controller ports for 1 or 2-player games. This version is smaller than the above and uses cheaper, but ultimately harder to solder components. This is a more advanced project than the above PCB design; if you are unsure of your soldering capabilities I wouldn't recommend this PCB.
 
 Several companies can make these PCBs for you. PCBWay or JLCPCB are two good options.
 
-I personally recommend [PCBWay](https://www.pcbway.com/). The boards I ordered from them are of excellent quality. They have also a very short lead time. Boards I ordered on Monday arrived from China to my home in the Netherlands on Friday of the same week.
+I personally recommend [PCBWay](https://www.pcbway.com/). The boards I ordered from them are of excellent quality. They also have a very short lead time. Boards I ordered on Monday arrived from China to my home in the Netherlands on Friday of the same week.
 
 [![Image](assets/pcbw.png)](https://www.pcbway.com/)
 
-When ordering, simply upload the zip file containing the gerber design.  This file (Gerber_PicoNES_Mini_PCB_v2.0.zip) is available in the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest) and can also be found in the [PCB folder of the pico_shared repository](https://github.com/fhoedemakers/pico_shared/tree/main/PCB). 
+When ordering, simply upload the zip file containing the gerber design.  This file (Gerber_PicoNES_Mini_PCB_v2.0.zip) is available on the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest) and can also be found in the [PCB folder of the pico_shared repository](https://github.com/fhoedemakers/pico_shared/tree/main/PCB). 
 
 > [!NOTE]
 >  Soldering skills are required. Make sure you solder all the connections from the Pico onto the PCB. This version requires good soldering skills especially for the HDMI portion, a good amount of flux and a fine tip will be required, additional solder can be wicked away with solder wick. I recommend starting with the resistor arrays first, then the HDMI port, after that either Pico or MicroSD adaptor, lastly the NES Ports, which can be hard to push into the PCB.
 
-Please see the Instrucables link for guide and components needed: https://www.instructables.com/PicoNES-RaspberryPi-Pico-Based-NES-Emulator/
+Please see the Instructables link for the guide and components needed: https://www.instructables.com/PicoNES-RaspberryPi-Pico-Based-NES-Emulator/
 
 
-When using a RP2040 Zero, Flash **[piconesPlus_WaveShareRP2040ZeroWithPCB_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_WaveShareRP2040ZeroWithPCB_arm.uf2)** from the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest). 
-When using a RP2350 Zero, flash **[piconesPlus_WaveShareRP2350PiZero_arm_piousb.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_WaveShareRP2350PiZero_arm_piousb.uf2)** instead.
+When using a RP2040 Zero, flash **[piconesPlus_WaveShareRP2040ZeroWithPCB_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_WaveShareRP2040ZeroWithPCB_arm.uf2)** from the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest). 
+When using a RP2350 Zero, flash **[piconesPlus_WaveShareRP2350ZeroWithPCB_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_WaveShareRP2350ZeroWithPCB_arm.uf2)** instead.
 
 
 ### 3D printed case for PCB
 
-Gavin Knight ([DynaMight1124](https://github.com/DynaMight1124)) designed a NES-like case you can 3D print as an enclosure for this PCB.  You can find it here: https://www.thingiverse.com/thing:7041536. If you dont own a 3D printer, you can either find a local company that can offer 3D print services or use professional services such as PCBWay or JCLPCB, the professional services can offer extremely high quaility finishes.
+Gavin Knight ([DynaMight1124](https://github.com/DynaMight1124)) designed a NES-like case you can 3D print as an enclosure for this PCB.  You can find it here: https://www.thingiverse.com/thing:7041536. If you don't own a 3D printer, you can either find a local company that offers 3D printing services or use professional services such as PCBWay or JLCPCB; the professional services can offer extremely high quality finishes.
 
 #### 3D printed case
 ![PXL_20250508_183050163](https://github.com/user-attachments/assets/732384bd-062d-43ca-97cb-a16a39607c41)
@@ -927,13 +960,17 @@ Gavin Knight ([DynaMight1124](https://github.com/DynaMight1124)) designed a NES-
 
 ## PCB with WaveShare RP2350 USB A
 
-Based around the WaveShare RP2350 USB A board along with a PCB, which creates a micro PicoNES with 1 player controls via USB. Theres a full guide here: https://www.instructables.com/PicoNES-RaspberryPi-Pico-Based-NES-Emulator/
+Based around the WaveShare RP2350 USB A board along with a PCB, which creates a micro PicoNES with 1 player controls via USB. There's a full guide here: https://www.instructables.com/PicoNES-RaspberryPi-Pico-Based-NES-Emulator/
 
 Several companies can make these PCBs for you. PCBWay or JLCPCB are two good options.
 
-I personally recommend [PCBWay](https://www.pcbway.com/). The boards I ordered from them are of excellent quality. They have also a very short lead time. Boards I ordered on Monday arrived from China to my home in the Netherlands on Friday of the same week.
+I personally recommend [PCBWay](https://www.pcbway.com/). The boards I ordered from them are of excellent quality. They also have a very short lead time. Boards I ordered on Monday arrived from China to my home in the Netherlands on Friday of the same week.
 
 [![Image](assets/pcbw.png)](https://www.pcbway.com/)
+
+When ordering, simply upload the zip file containing the gerber design. This file (Gerber_PicoNES_Micro_v1.2.zip) is available on the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest) and can also be found in the [PCB folder of the pico_shared repository](https://github.com/fhoedemakers/pico_shared/tree/main/PCB).
+
+Flash **[piconesPlus_WaveShare2350USBA_arm_piousb.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_WaveShare2350USBA_arm_piousb.uf2)** from the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest). The game controller connects to the USB A port; the USB-C port is used for power and for flashing the firmware.
 
 #### PicoNES Micro populated PCB - NES controller shown for scale
 ![PXL_20250804_160007569](https://github.com/user-attachments/assets/59c8a31b-dc3e-47b0-8ffb-89e1eab2a75b)
@@ -960,7 +997,7 @@ Download the metadata pack from the [releases page](https://github.com/fhoedemak
 
 # Gamepad and keyboard usage
 
-|     | (S)NES | Genesis | XInput | Dual Shock/Sense | 
+|     | (S)NES | Genesis | XInput | DualShock/DualSense | 
 | --- | ------ | ------- | ------ | ---------------- |
 | Button1 | B  |    A    |   A    |    X             |
 | Button2 | A  |    B    |   B    |   Circle         |
@@ -973,40 +1010,72 @@ Gamepad buttons:
 - Button2: Open folder/flash and start game.
 - Button1: Back to parent folder.
 - START: Show [metadata](#using-metadata) and box art (when available)
-- SELECT: Opens a setting menu. Here you can change settings like screen mode, scanlines, framerate display, menu colors and other board specific settings. Settings can also be changed in-game by pressing some button combinations as explained below. The settings menu can also be opened in-game.
-- SELECT + Button1: Force DVI mode (HSTX only). Useful if a DVI monitor shows no picture. This will restore the image. Enabling **External audio** also forces DVI mode.
+- SELECT: Opens the settings menu. Here you can change settings like screen mode, scanline type, framerate display, menu colours and other board specific settings. The settings menu can also be opened in-game. See [Settings menu](#settings-menu) below for the full list.
+- SELECT + Button2: Force DVI mode (HSTX only). Useful if a DVI monitor shows no picture. This will restore the image.
 
-When using an USB-Keyboard:
+When using a USB keyboard:
 - Cursor keys: Up, Down, left, right
 - Z: Back to parent folder
 - X: Open Folder/flash and start a game
 - S: Show [metadata](#using-metadata) and box art (when available).
 - A: acts as the select button.
 
+## Settings menu
+
+The settings menu is opened with SELECT from the main menu, or with SELECT + START while a game is
+running. Not every entry is available on every board or in every situation.
+
+| Setting | Description |
+| ------- | ----------- |
+| Select disk | Change the FDS disk side. Only for FDS games, and always the first entry. |
+| Quit game / Back to main menu | Leave the game and return to the SD card menu. Battery-backed save RAM is written to the SD card here. In-game only. |
+| Reset game | Reset the running game. In-game only. |
+| Save/Load State | Manage save states. In-game only. |
+| Screen Mode | Cycle the screen modes, including the 8:7 pixel aspect ratio modes. |
+| Scanline Type | Simple or LCD style scanlines. HSTX boards only. |
+| Framerate Overlay | Show the frames per second on screen. |
+| Display Mode | HDMI or DVI output. HSTX boards only. |
+| External Audio | Route audio to the I2S/line-out output instead of HDMI. Selecting DVI as Display Mode enables this automatically, because DVI carries no audio. |
+| Menu Font Color / Menu Font Back Color | Menu colours (0-63). |
+| Fruit Jam VU Meter / Fruit Jam Volume Control | Fruit Jam only. |
+| Rapid Fire on A / Rapid Fire on B | Enable rapid fire per button. |
+| FDS Auto Swap Disk side | Swap the disk side automatically when the game asks for it. Off by default. FDS games only. |
+| FDS Auto Insert Disk 1 On Start | Insert disk 1 automatically at start. On by default. FDS games only. |
+| Overclock | Raise the CPU clock from 252 MHz to 378 MHz. Only on HSTX boards with PSRAM, and currently only needed for *Lagrange Point (JP)*. Menu only, not available in-game. |
+| Enter BOOTSEL Mode | Reboot into BOOTSEL so you can flash new firmware. |
+| Controller Test | Show a gamepad graphic that follows the controller you last pressed a button on, plus a list of connected input sources. Useful for checking wiring and button mappings. Hold SELECT + START for 2 seconds to exit. |
+| Return to emulator selection | Go back to the emulator picker. Only present in [pico-bootLoader](#running-under-pico-bootloader) builds. |
+
+> [!NOTE]
+> Changes are only applied when you select **SAVE**. **CANCEL** discards them, **DEFAULT** restores the default values.
+
 ## Emulator (in game)
 Gamepad buttons:
 - SELECT + START, Xbox button: opens the settings menu. From there, you can:
   - Quit the game and return to the SD card menu
-  - Manage save states. Load or save your game state to one of 5 slots. Enable auto save/load state on exit/start.
+  - Reset the game
+  - Manage save states. Load or save your game state to one of 5 slots plus a quick save slot. Enable auto save/load state on exit/start.
   - Adjust settings and resume your game.
-- SELECT + UP/SELECT + DOWN: switches screen modes.
-- SELECT + Button1/Button2: toggle rapid-fire.
+- SELECT + UP/SELECT + DOWN: switches screen modes, including the 8:7 pixel aspect ratio modes.
 - START + Button2: Toggle framerate display
-- START + DOWN : (quick) Save state. (slot 5)
-- START + UP : (quick) Load state. (slot 5)
-- **Pimoroni Pico DV Demo Base only**: SELECT + LEFT: Switch audio output to the connected speakers on the line-out jack of the Pimoroni Pico DV Demo Base. The speaker setting will be remembered when the emulator is restarted.
+- START + DOWN : (quick) Save state. (Quick Save slot)
+- START + UP : (quick) Load state. (Quick Save slot)
+- SELECT + START + UP + Button2 (all held together): Reboot into BOOTSEL mode for flashing new firmware.
+- **Pimoroni Pico DV Demo Base and Murmulator only**: SELECT + LEFT: Switch audio output to the connected speakers on the line-out jack. The speaker setting will be remembered when the emulator is restarted. Not available on boards that output audio over HDMI.
 - **Fruit Jam Only** 
-  - SELECT + UP: Toggle scanlines.   
   - pushbutton 2 (on board) or SELECT + RIGHT: Toggles the VU meter on or off. (NeoPixel LEDs light up in sync with the music rhythm)
   - START + LEFT/RIGHT: Adjust volume of built-in speaker and external audio jack.
-- **RP2350 with PSRAM only**: Record about 30 seconds of audio by pressing START to pause the game and then START + BUTTON1. Audio is recorded to **/soundrecorder.wav** on the SD-card.
-- **Genesis Mini Controller**: When using a Genesis Mini controller with 3 buttons, press C for SELECT. 8 buttons Genesis controllers press MODE for SELECT
-- **USB-keyboard**: When using an USB-Keyboard
+- **RP2350 with PSRAM only**: Record about 30 seconds of audio by pressing START to pause the game and then START + Button1. Audio is recorded to **/soundrecorder.wav** on the SD card.
+- **Genesis Mini Controller**: When using a Genesis Mini controller with 3 buttons, press C for SELECT. On 8-button Genesis controllers, press MODE for SELECT.
+- **USB keyboard**: When using a USB keyboard
   - Cursor keys: up, down, left, right
   - A: SELECT
   - S: START
   - Z: Button1
   - X: Button2
+
+> [!NOTE]
+> Rapid fire is not a button combination. Enable it per button with the **Rapid Fire on A** / **Rapid Fire on B** entries in the settings menu.
 
 Save States should work for  mapper 0,1,2,3 and 4. Other mappers may or may not work. Below the games that use these mappers.
 
@@ -1023,34 +1092,36 @@ Save States should work for  mapper 0,1,2,3 and 4. Other mappers may or may not 
 
 FDS games are supported with the following requirements:
 
-- A BIOS file is required. Place it at `/bios/fds-bios.rom` on the SD card.
+- A BIOS file is required. Place it at `/bios/fds-bios.rom` on the SD card. The file must be exactly 8 KB.
 - An RP2350 board. RP2040 does not meet the memory requirements.
-- You need roms with the `.fds` extension.
+- You need ROMs with the `.fds` extension.
 
 FDS games have these features:
 
-- For games that support write save data back to disk, you must go back to the menu to save the game. Saves are written to `/saves/gamename_fds.sav`. Save states are not supported for FDS games.
+- For games that can write save data back to disk, you must go back to the menu to save the game. Saves are written to `/SAVES/<gamename>_fds.SAV`. For single-side disk images the file is `/SAVES/<gamename>_fds_s<N>.SAV`, one per side. Save states are not supported for FDS games.
   
 ### Swapping Disks
 
 When prompted to swap disks, use the in-game settings menu:
 
 1. Press **SELECT + START** to open the settings menu.
-2. Select the first option to change the disk.
+2. Select the first option (**Select disk**) to change the disk.
 3. Press **LEFT/RIGHT** to choose the disk side.
 4. Press **Button2** to confirm and return.
 
 ### Auto Swapping disks
 
-In the settings menu, there is an option **Auto Swap FDS Disks**. This is disabled by default. When enabled, the emulator will automatically swap disks when needed. Note that in some cases you still need to manually swap the disks.
+In the settings menu, there is an option **FDS Auto Swap Disk side**. This is disabled by default. When enabled, the emulator will automatically swap the disk side when the game asks for it. Note that in some cases you still need to swap the disks manually.
+
+There is a second FDS option, **FDS Auto Insert Disk 1 On Start**, which inserts disk 1 automatically when the game starts. This one is enabled by default.
 
 ***
 
 # Playing NSF audio files
 
-The emulator can play Nintendo Sound Format files. These are roms with the `.nsf` extension. This works on both the RP2040 and RP2350 boards.
+The emulator can play Nintendo Sound Format files. These are ROMs with the `.nsf` extension. This works on both the RP2040 and RP2350 boards.
 
-Each NSF file can have multiple tracks. Loading a `.nsf` rom from the menu will automatically start the first track.  Each track is played for the maximum duration of 3 minutes. Then the next track is played. When there is silence for more than 4 seconds, the next track is played.
+Each NSF file can have multiple tracks. Loading a `.nsf` ROM from the menu will automatically start the first track.  Each track is played for a maximum duration of 3 minutes, after which the next track is played. When there is silence for more than 3 seconds, the next track is played as well.
 
 **Controls**
 
@@ -1068,10 +1139,13 @@ Each NSF file can have multiple tracks. Loading a `.nsf` rom from the menu will 
 The menu allows you to play music files. Files must meet the following requirements:
 
 - **Format:** WAV  
-- **Bit depth:** 16-bit  
+- **Bit depth:** 16-bit or 24-bit  
 - **Sample rate:** 44.1 kHz  
 - **Channels:** Stereo  
 - **File extension:** `.wav`  
+
+> [!NOTE]
+> The sample rate is not checked. There is no resampler, so a file recorded at a different sample rate will play back at the wrong speed.
 
 ## How to Play
 1. Select a music file from the menu.
@@ -1093,28 +1167,31 @@ You can easily convert MP3 files to WAV using [Audacity](https://www.audacitytea
 ***
 
 # Save games
-For games which support it, saves will be stored in the /SAVES folder of the SD card. Caution: the save ram will only be saved back to the SD card when quitting the game via (START + SELECT)
+For games which support it, battery-backed save RAM is stored in the `/SAVES` folder of the SD card, as `<gamename>.SAV`.
+
+> [!CAUTION]
+> The save RAM is only written back to the SD card when you quit the game properly: press **SELECT + START** to open the settings menu, then choose **Quit game**. Powering off or resetting the board while the game is running loses everything since the last save.
 
 ***
 
 # Raspberry Pico W and Pico2 W support
-The emulator works with the Pico W (RP2040). Use the pico_w_ or pico2_w_ versions of the uf2 files in the latest release. The Pico W has a built-in wifi module. The wifi module is not used by the emulator. It is only used for enabling the led to blink every 60 frames on the Pico W.  If you don't mind the led blinking, you can use the pico_ versions of the uf2 files on the Pico W.
+The emulator works with the Pico W (RP2040). Use the pico_w_ or pico2_w_ versions of the uf2 files in the latest release. The Pico W has a built-in wifi module. The wifi module is not used by the emulator. It is only used for enabling the LED to blink every 60 frames on the Pico W.  If you don't mind the LED blinking, you can use the pico_ versions of the uf2 files on the Pico W.
 
 ***
 
-# USB game Controllers latency
-Using a USB gamecontroller introduces some latency. The legacy controllers ((S)NES, WII-classic) have less latency.
+# USB game controller latency
+Using a USB game controller introduces some latency. The legacy controllers ((S)NES, Wii Classic) have less latency.
 
 ***
 
-# Troubleshooting usb controllers
+# Troubleshooting USB controllers
 
 ## AliExpress Controllers (Mantapad)
 
-When starting a game, and the controller is unresponsive, you have to unplug and replug the controller to get it working. Not all controllers behave this way. I have a SNES controller that has no problems. The NES controller however must alwas be replugged to make it work. It is kind of a hit and miss.
+When starting a game, and the controller is unresponsive, you have to unplug and replug the controller to get it working. Not all controllers behave this way. I have a SNES controller that has no problems. The NES controller however must always be replugged to make it work. It is kind of hit and miss.
 
 > [!NOTE]
-> When using a SNES style usb controller, press Y to properly setup the controller. Otherwise the B button will not work. You have to do this every time you start a game or boot into the menu.
+> When using a SNES style USB controller, press Y to set the controller up properly. Otherwise the B button will not work. You have to do this every time you start a game or boot into the menu.
 
 
 ## XInput style controllers.
@@ -1158,7 +1235,30 @@ Some displays need 5V connected to the HDMI breakout in order to work:
 # Known Issues and limitations
 
 - Not all games will run, as some mappers are either not fully implemented or exceed memory limitations. If a game uses an unsupported mapper, the system will display a message such as: "Mapper n is unsupported." (where n is the mapper number). For example, attempting to start Castlevania III (US) on the RP2040 will result in the message: "Mapper 5 is unsupported." On the RP2350, however, this game runs without issues.
-- tar file support is removed.
+- MMC5 and VRC7 expansion audio require an RP2350 board. VRC6, FDS and Sunsoft 5B expansion audio also work on the RP2040.
+- The VRC7 (Yamaha OPLL) FM audio used by *Lagrange Point (JP)* only works on HSTX boards with PSRAM and requires the **Overclock** setting to be enabled. The audio may still show occasional glitches.
+- Save states are not supported for FDS games.
+
+***
+
+# Running under pico-bootLoader
+
+Instead of flashing this emulator as the only application on your board, you can install it under [pico-bootLoader](https://github.com/fhoedemakers/pico-bootLoader). The bootloader turns an RP2350 board into a multi-system console: on power-on it shows a menu from which you pick an emulator or game, which is then launched straight from the SD card. Any reset or power cycle brings you back to that menu, so you no longer have to reconnect the board to a computer to switch systems.
+
+Alongside this NES emulator, the bootloader can run the Game Boy, Sega Master System/Game Gear, Sega Mega Drive/Genesis, PC Engine, Philips Videopac emulators and a native Doom port.
+
+**You do not have to build anything.** The bootloader's releases page provides a prebuilt bootloader UF2 for each supported board plus `pico-bootLoader_sdcard.zip`, an SD card archive that already contains a ready-to-use `piconesPlus` build. In short:
+
+1. Flash the bootloader UF2 for your board via BOOTSEL.
+2. Unpack `pico-bootLoader_sdcard.zip` onto a FAT32 or exFAT SD card.
+3. Insert the card and power on.
+
+> [!NOTE]
+> pico-bootLoader requires an RP2350 board. Supported configurations are the Pimoroni Pico DV Demo Base, Adafruit DVI + SD breakout, Adafruit Metro RP2350, Waveshare RP2350-Zero with PCB, Waveshare RP2350-PiZero, Adafruit Fruit Jam, Waveshare RP2350-USB A, Murmulator M2 and the Adafruit Feather RP2350. See the bootloader's own readme for the current list and for the SD card layout.
+
+When the emulator runs under the bootloader, the settings menu gains an extra **Return to emulator selection** entry that takes you back to the picker.
+
+If you do want to build the emulator for the bootloader yourself, use the `-b` flag described in [Building from source](#building-from-source). Those builds are relinked to the application partition at `0x10080000` and are written to the `releases_bl` folder instead of `releases`. Note that the regular binaries on this project's releases page are standalone builds and will **not** work under the bootloader.
 
 ***
 
@@ -1179,13 +1279,16 @@ Alternatively, you can use the [bld.sh](bld.sh) shell script:
 ```
 Build script for the piconesPlus project
 
-Usage: ./pico_shared/bld.sh [-d] [-2 | -r] [-w] [-u] [-m] [-D] [-t path to toolchain] [ -p nprocessors] [-c <hwconfig>]
+Usage: ./pico_shared/bld.sh [-d] [-2 | -r] [-w] [-u] [-m] [-D] [-e] [-b] [-t path to toolchain] [ -p nprocessors] [-c <hwconfig>]
 Options:
   -d: build in DEBUG configuration
   -2: build for Pico 2 board (RP2350)
   -r: build for Pico 2 board (RP2350) with riscv core
-  -u: enable PIO USB support (RP2350 only) disabled by default except for Waveshare RP2350-PiZero and Adafruit Fruit Jam.
+  -u: (RP2350 only, must also use -2) enable PIO USB support (RP2350 only) disabled by default except for Waveshare RP2350-PiZero and Adafruit Fruit Jam.
   -w: build for Pico_w or Pico2_w
+  -b: (RP2350 only, must also use -2) build for the resident emuLoader bootloader (passes -DBUILD_FOR_BOOTLOADER=ON;
+      relinks the image to the application partition at 0x10080000 instead of 0x10000000).
+      Copies the resulting UF2 to releases_bl instead of releases.
   -t <path to riscv toolchain>: only needed for riscv, specify the path to the riscv toolchain bin folder
      Default is $PICO_SDK_PATH/toolchain/RISCV_RPI_2_0_0_2/bin
   -p <nprocessors>: specify the number of processors to use for the build
@@ -1207,6 +1310,7 @@ Options:
      13: Murmulator M2 (rp2350 only)
      14: Adafruit Feather RP2350 with TLV320DAC3100 I2S DAC and sdcard breakout board and PIO USB.
   -m: Run cmake only, do not build the project
+  -e: use the pico-extras based I2S audio driver (default: legacy custom driver)
   -h: display this help
 
 To install the RISC-V toolchain:
@@ -1226,9 +1330,10 @@ To build for riscv:
 
         ./bld.sh -c <hwconfig> -r -t $PICO_SDK_PATH/toolchain/RISCV_RPI_2_0_0_2/bin
 
+Note: All .uf2 files are copied to the releases folder, except for the bootloader (-b) build which is copied to releases_bl
 ```
 
-When using Visual Studio code, choose the Release or the RelWithDebuginfo build variant.
+When using Visual Studio Code, choose the Release or the RelWithDebInfo build variant.
 
 ## Building with an embedded ROM
 
@@ -1252,7 +1357,7 @@ cmake --build . -j$(nproc)
 
 ## Building with support for an additional USB port using PIO-USB
 
-In some configurations, a second USB port can be added. This port can be used to connect a gamepad. The built-in usb port will be used for power and flashing the firmware.
+In some configurations, a second USB port can be added. This port can be used to connect a gamepad. The built-in USB port will be used for power and flashing the firmware.
 With this there is no need to use a USB-Y cable anymore.
 
 For more info on how to setup and build the firmware, see [pio_usb.md](pio_usb.md).
@@ -1263,21 +1368,21 @@ For more info on how to setup and build the firmware, see [pio_usb.md](pio_usb.m
 ***
 
 # Credits
-InfoNes is programmed by [Jay Kumogata](https://github.com/jay-kumogata/InfoNES) and ported to the Raspberry Pi Pico by [Shuichi Takano](https://github.com/shuichitakano/pico-infones).
+InfoNES is programmed by [Jay Kumogata](https://github.com/jay-kumogata/InfoNES) and ported to the Raspberry Pi Pico by [Shuichi Takano](https://github.com/shuichitakano/pico-infones).
 
-I contributed by programming functionality for SD card, menu, 2-player games, support for various USB gamepads and keyboard, metdata rendering etc...
+I contributed by programming functionality for SD card, menu, 2-player games, support for various USB gamepads and keyboard, metadata rendering etc...
 
 HSTX HDMI/DVI driver with audio using [pico_hdmi](https://github.com/fliperama86/pico_hdmi) by [fliperama86](https://github.com/fliperama86)
 
 PCB design by [John Edgar Park](https://twitter.com/johnedgarpark).
 
-Additional PCB design and 3D-printable case for both PCB's and WaveShare RP2040/RP2350-PiZero by [Gavin Knight](https://github.com/DynaMight1124)
+Additional PCB design and 3D-printable case for both PCBs and WaveShare RP2040/RP2350-PiZero by [Gavin Knight](https://github.com/DynaMight1124)
 
 Metadata files provided by [Gavin Knight](https://github.com/DynaMight1124), based on [Ducalex's retro-go-covers](https://github.com/ducalex/retro-go-covers)
 
 NES gamepad support contributed by [PaintYourDragon](https://github.com/PaintYourDragon) & [Adafruit](https://github.com/adafruit). 
 
-WII-Classic controller support by [PaintYourDragon](https://github.com/PaintYourDragon) & [Adafruit](https://github.com/adafruit).
+Wii Classic controller support by [PaintYourDragon](https://github.com/PaintYourDragon) & [Adafruit](https://github.com/adafruit).
 
 Adafruit Feather DVI - RP2040 support by [PaintYourDragon](https://github.com/PaintYourDragon) & [Adafruit](https://github.com/adafruit).
 
@@ -1293,20 +1398,21 @@ Audio feedback and fixes: [szuping](https://github.com/szuping)
 
 Mesen: https://github.com/SourMesen/Mesen2 used as basis for:
 
-- NES rom database 
+- NES ROM database 
 - FDS implementation
 - NSF playback
 
 [Anthropic Claude Opus 4.6 and 4.7](https://www.anthropic.com/claude/opus) assisted with: 
 
 - Famicom Disk System (FDS) support
-- mapper 5 (MMC5)
+- mapper 5 (MMC5), including its expansion audio
 - mapper 24 (VRC6a)
 - mapper 30
-- mapper 85
+- mapper 85 (VRC7), including the Yamaha OPLL FM audio
+- mapper 69 (Sunsoft FME-7), including the YM2149 PSG audio
 - fixes in other mappers
 - NSF player support
-- general code optimizations and bug fixes
+- general code optimisations and bug fixes
 
 
 ***

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Click on image below to see a demo video.
 
 You can use it with these RP2040/RP2350 boards and configurations:
     
-  - A custom printed circuit board (PCB) designed by [@johnedgarpark](https://twitter.com/johnedgarpark). (requires soldering) Up to two NES controller ports can be added to this PCB. Can also be used with a USB game controller. You can 3D print your own NES-like case for the PCB. The current design (v2.3) has through-holes, so besides a Raspberry Pi Pico or Pico 2 you can also use a Pimoroni Pico Plus 2, as long as it has soldered male headers.
+  - A custom printed circuit board (PCB) designed by [@johnedgarpark](https://twitter.com/johnedgarpark). (requires soldering) Up to two NES controller ports can be added to this PCB. Can also be used with a USB game controller. You can 3D print your own NES-like case for the PCB. The current design (v2.1) requires a Raspberry Pi Pico or Pico 2 **without** headers, soldered flat onto the board.
     
   - An additional PCB design for Waveshare RP2040 & RP2350 Zero including case design by DynaMight1124 based around cheaper but harder to solder components for those that fancy a bigger challenge. It also allows the design to be smaller.
 
@@ -99,9 +99,8 @@ You can use it with these RP2040/RP2350 boards and configurations:
 
 - [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107)
 
-  Can be used in three ways:
+  Can be used in two ways:
   - On a breadboard with the [Adafruit DVI Breakout For HDMI Source Devices](https://www.adafruit.com/product/4984) and the [Adafruit Micro-SD breakout board+](https://www.adafruit.com/product/254). For use with a USB game controller or up to two legacy NES controllers. (No soldering required)
-  - On the [custom PCB](#pcb-with-raspberry-pi-pico-or-pico-2), from design v2.3 onwards, provided male headers are soldered onto it.
   - On the discontinued [Pimoroni Pico DV Demo Base](https://shop.pimoroni.com/products/pimoroni-pico-dv-demo-base?variant=39494203998291) HDMI add-on board. For use with a USB game controller or up to two legacy NES controllers. (NES controller ports require soldering)
   
   The PSRAM on the board is used instead of flash to load the ROMs from SD.
@@ -245,7 +244,7 @@ Click on the link below for your specific board configuration:
   * [3D printed case for this board](#3d-printed-case-for-rp2040rp2350-pizero)
 - [Waveshare RP2350-PiZero Development Board](#waveshare-rp2040rp2350-pizero-development-board)
   * [3D printed case for this board](#3d-printed-case-for-rp2040rp2350-pizero)
-- [Printed Circuit Board (PCB) for Raspberry Pi Pico, Pico 2 or Pimoroni Pico Plus 2](#pcb-with-raspberry-pi-pico-or-pico-2)
+- [Printed Circuit Board (PCB) for Raspberry Pi Pico or Pico 2](#pcb-with-raspberry-pi-pico-or-pico-2)
   * [3D printed case for this PCB](#3d-printed-case-for-pcb)
 - [PCB with WaveShare RP2040/RP2350 Zero](#pcb-with-waveshare-rp2040rp2350-zero)
   * [3D printed case for this PCB](#3d-printed-case)
@@ -845,7 +844,7 @@ Create your own Pico-based NES console. It features two NES controller ports for
 
 Designed by [@johnedgarpark](https://twitter.com/johnedgarpark)
 
-<img width="4284" height="5712" alt="IMG_1551" src="https://github.com/user-attachments/assets/c26edd6f-1407-4f7e-869f-abd8ffe5bae8" />
+![IMG_6011](https://github.com/user-attachments/assets/a55dd2ad-75a8-4115-a38f-fe0ecd6f51c7)
 
 
 Several companies can make these PCBs for you. 
@@ -854,11 +853,10 @@ I personally recommend [PCBWay](https://www.pcbway.com/). The boards I ordered f
 
 [![Image](assets/pcbw.png)](https://www.pcbway.com/)
 
-When ordering, simply upload the zip file containing the gerber design.  This file (pico_nesPCB_v2.3.zip) is available on the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest) and can also be found in the [PCB folder of the pico_shared repository](https://github.com/fhoedemakers/pico_shared/tree/main/PCB). 
+When ordering, simply upload the zip file containing the gerber design.  This file (pico_nesPCB_v2.1.zip) is available on the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest) and can also be found in the [PCB folder of the pico_shared repository](https://github.com/fhoedemakers/pico_shared/tree/main/PCB). 
 
 > [!NOTE]
-> Design v2.3 adds through-holes for the Pico. You can either solder the board flat onto the PCB as before, or plug in a Raspberry Pi Pico, Pico 2 or [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) fitted with male headers. Designs up to and including v2.1 have no through-holes and require the board to be soldered flat.
-> When you mount the Pico with headers, make sure to print the latest top cover from Thingiverse, see [3D printed case for PCB](#3d-printed-case-for-pcb).
+> The current design is v2.1. It has no through-holes for pin headers, so the Raspberry Pi Pico or Pico 2 has to be soldered flat onto the PCB.
 
 > [!NOTE]
 >  Soldering skills are required. Make sure you solder all the connections from the Pico onto the PCB. Also the connections on the short right-side of the Pico. (For ground)
@@ -871,9 +869,7 @@ When ordering, simply upload the zip file containing the gerber design.  This fi
 
 Other materials needed:
 
-- One of the following, depending on how you want to mount it onto the PCB:
-  * Raspberry Pi Pico or Pico 2 **with no headers**, soldered flat onto the PCB. Works with every design version.
-  * Raspberry Pi Pico, Pico 2 or [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) **with soldered male headers**, plugged into the through-holes. Requires design v2.3 or later, see the note above. You can use [these headers](https://a.co/d/dSNPuyo).
+- Raspberry Pi Pico or Pico 2 **with no headers**, soldered flat onto the PCB.
 - [Adafruit DVI Breakout Board - For HDMI Source Devices](https://www.adafruit.com/product/4984)
 - [Adafruit Micro SD SPI or SDIO Card Breakout Board - 3V ONLY!](https://www.adafruit.com/product/4682)
 - For the NES controllers:
@@ -885,10 +881,9 @@ Other materials needed:
 
 When using a Pico / Pico W, Flash **[piconesPlus_AdafruitDVISD_pico_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico_arm.uf2)** / **[piconesPlus_AdafruitDVISD_pico_w_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico_w_arm.uf2)** from the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest). 
 When using a Pico 2 or Pico 2 W, flash **[piconesPlus_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_arm.uf2)** / **[piconesPlus_AdafruitDVISD_pico2_w_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_w_arm.uf2)** instead.
-When using a Pimoroni Pico Plus 2, flash **[piconesPlus_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_arm.uf2)** as well. The PSRAM on the board is used instead of flash to load the ROMs from SD.
 
 > [!IMPORTANT]
-> A [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) can only be used with design v2.3 or later, and only when male headers are soldered onto it. On v2.1 and older designs the board has to lie flat on the PCB, which the SP/CE connector on the back of the Pico Plus 2 prevents.
+> A [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) cannot be used with this PCB. The board has to lie flat on the PCB, which the SP/CE connector on the back of the Pico Plus 2 prevents.
 
 ### Image: Two player setup using two NES controllers or a USB controller and a NES controller
 
@@ -902,9 +897,6 @@ Choose either of the following:
 ### 3D printed case for PCB
 
 Gavin Knight ([DynaMight1124](https://github.com/DynaMight1124)) designed a NES-like case you can 3D print as an enclosure for this PCB.  You can find it here: [https://www.thingiverse.com/thing:6689537](https://www.thingiverse.com/thing:6689537). Here you can find two designs: the latest design for PCB v2.0  and the previous design for [PCB v0.2](PCB/v0.2). In the latest v2.0 design, you can choose between two top covers, one with a button connecting to the bootsel button for easy firmware upgrades, the other without the button. In this case you have to remove the top cover to access the bootsel button. See images below. Make sure to print the correct files for the PCB version you own. You can find more information on Gavin's Thingiverse page.
-
-> [!IMPORTANT]
-> When the Pico is plugged into the through-holes of PCB v2.3 with male headers, always download the **latest** top case design from Thingiverse. Because the Pico sits higher on the board when headers are used, only the newest top cover leaves enough room for the USB cable to fit. The older covers were designed for a Pico soldered flat onto the PCB.
 
 #### Top Cover v2.0 without button (Top_v2.0.stl)
 ![Top cover without button](https://github.com/user-attachments/assets/c6205db3-580e-41e9-83e4-66c9534c6519)

--- a/README.md
+++ b/README.md
@@ -812,7 +812,8 @@ Create your own Pico-based NES console. It features two NES controller ports for
 
 Designed by [@johnedgarpark](https://twitter.com/johnedgarpark)
 
-![IMG_6011](https://github.com/user-attachments/assets/a55dd2ad-75a8-4115-a38f-fe0ecd6f51c7)
+<img width="4284" height="5712" alt="IMG_1551" src="https://github.com/user-attachments/assets/c26edd6f-1407-4f7e-869f-abd8ffe5bae8" />
+
 
 Several Companies  can make these PCBs for you. 
 

--- a/README.md
+++ b/README.md
@@ -858,6 +858,7 @@ When ordering, simply upload the zip file containing the gerber design.  This fi
 
 > [!NOTE]
 > Design v2.3 adds through-holes for the Pico. You can either solder the board flat onto the PCB as before, or plug in a Raspberry Pi Pico, Pico 2 or [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) fitted with male headers. Designs up to and including v2.1 have no through-holes and require the board to be soldered flat.
+> When you mount the Pico with headers, make sure to print the latest top cover from Thingiverse, see [3D printed case for PCB](#3d-printed-case-for-pcb).
 
 > [!NOTE]
 >  Soldering skills are required. Make sure you solder all the connections from the Pico onto the PCB. Also the connections on the short right-side of the Pico. (For ground)
@@ -901,6 +902,9 @@ Choose either of the following:
 ### 3D printed case for PCB
 
 Gavin Knight ([DynaMight1124](https://github.com/DynaMight1124)) designed a NES-like case you can 3D print as an enclosure for this PCB.  You can find it here: [https://www.thingiverse.com/thing:6689537](https://www.thingiverse.com/thing:6689537). Here you can find two designs: the latest design for PCB v2.0  and the previous design for [PCB v0.2](PCB/v0.2). In the latest v2.0 design, you can choose between two top covers, one with a button connecting to the bootsel button for easy firmware upgrades, the other without the button. In this case you have to remove the top cover to access the bootsel button. See images below. Make sure to print the correct files for the PCB version you own. You can find more information on Gavin's Thingiverse page.
+
+> [!IMPORTANT]
+> When the Pico is plugged into the through-holes of PCB v2.3 with male headers, always download the **latest** top case design from Thingiverse. Because the Pico sits higher on the board when headers are used, only the newest top cover leaves enough room for the USB cable to fit. The older covers were designed for a Pico soldered flat onto the PCB.
 
 #### Top Cover v2.0 without button (Top_v2.0.stl)
 ![Top cover without button](https://github.com/user-attachments/assets/c6205db3-580e-41e9-83e4-66c9534c6519)

--- a/README.md
+++ b/README.md
@@ -820,7 +820,7 @@ I personally recommend [PCBWay](https://www.pcbway.com/). The boards i ordered f
 
 [![Image](assets/pcbw.png)](https://www.pcbway.com/)
 
-When ordering, simply upload the zip file containing the gerber design.  This file (pico_nesPCB_v2.1.zip) is available in the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest) and can also be found in the [PCB](PCB/) folder. 
+When ordering, simply upload the zip file containing the gerber design.  This file (pico_nesPCB_v2.3.zip) is available in the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest) and can also be found in the [pico_shared/PCB](pico_shared/PCB/) folder. 
 
 > [!NOTE]
 >  Soldering skills are required. Make sure you solder all the connections from the Pico onto the PCB. Also the connections on the short right-side of the Pico. (For ground)

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Click on the link below for your specific board configuration:
   * [3D printed case for this board](#3d-printed-case-for-rp2040rp2350-pizero)
 - [Waveshare RP2350-PiZero Development Board](#waveshare-rp2040rp2350-pizero-development-board)
   * [3D printed case for this board](#3d-printed-case-for-rp2040rp2350-pizero)
-- [Printed Circuit Board (PCB) for Raspberry Pi Pico or Pico 2](#pcb-with-raspberry-pi-pico-or-pico-2)
+- [Printed Circuit Board (PCB) for Raspberry Pi Pico, Pico 2 or Pimoroni Pico Plus 2](#pcb-with-raspberry-pi-pico-or-pico-2)
   * [3D printed case for this PCB](#3d-printed-case-for-pcb)
 - [PCB with WaveShare RP2040/RP2350 Zero](#pcb-with-waveshare-rp2040rp2350-zero)
   * [3D printed case for this PCB](#3d-printed-case)
@@ -851,6 +851,7 @@ Other materials needed:
 
 When using a Pico / Pico W, Flash **[piconesPlus_AdafruitDVISD_pico_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico_arm.uf2)** / **[piconesPlus_AdafruitDVISD_pico_w_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico_w_arm.uf2)** from the [releases page](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest). 
 When using a Pico 2 or Pico 2 W, flash **[piconesPlus_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_arm.uf2)** / **[piconesPlus_AdafruitDVISD_pico2_w_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_w_arm.uf2)** instead.
+When using a Pimoroni Pico Plus 2, flash **[piconesPlus_AdafruitDVISD_pico2_arm.uf2](https://github.com/fhoedemakers/pico-infonesPlus/releases/latest/download/piconesPlus_AdafruitDVISD_pico2_arm.uf2)** as well. The PSRAM on the board is used instead of flash to load the roms from SD.
 
 > [!IMPORTANT]
 > A [Pimoroni Pico Plus 2](https://shop.pimoroni.com/products/pimoroni-pico-plus-2?variant=42092668289107) can only be used with design v2.3 or later, and only when male headers are soldered onto it. On v2.1 and older designs the board has to lie flat on the PCB, which the SP/CE connector on the back of the Pico Plus 2 prevents.


### PR DESCRIPTION
This pull request updates documentation and build configuration to reflect changes in PCB file management and provides important instructions for users with specific hardware. The most significant changes include moving PCB design files to the `pico_shared` repository, updating download and release paths, and adding detailed guidance for users with non-Winbond flash chips and PSRAM.

**PCB file management and build configuration:**
- Updated the build workflow in `.github/workflows/BuildAndRelease.yml` to fetch PCB-related zip files from `pico_shared/PCB/` instead of the local `PCB/` directory.
- Updated the `pico_shared` submodule to the latest commit, ensuring the project uses the most recent shared PCB files.
- Changed `PCB/README.md` to note that PCB design files are now maintained in the `pico_shared` repository, and the local files are kept for reference only.

**User guidance for non-Winbond flash chips with PSRAM:**
- Added a new section to `CHANGELOG.md` explaining issues and permanent fixes for boards with PSRAM and non-Winbond flash chips, including step-by-step instructions and warnings.
- Updated hardware compatibility tables and board-specific instructions in `CHANGELOG.md` to reference the new guidance for affected boards (Waveshare RP2350-PiZero, RP2350-Zero, and RP2350-USBA with PCB). [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL154-R166) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL194-R208) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR218-R219)